### PR TITLE
Rename model provider agent

### DIFF
--- a/inconsistency-detection/pipeline-id/src/main/java/edu/kit/kastel/mcse/ardoco/id/execution/runner/ArDoCoForInconsistencyDetection.java
+++ b/inconsistency-detection/pipeline-id/src/main/java/edu/kit/kastel/mcse/ardoco/id/execution/runner/ArDoCoForInconsistencyDetection.java
@@ -13,8 +13,8 @@ import edu.kit.kastel.mcse.ardoco.core.execution.ArDoCo;
 import edu.kit.kastel.mcse.ardoco.core.execution.runner.ArDoCoRunner;
 import edu.kit.kastel.mcse.ardoco.id.InconsistencyChecker;
 import edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.ConnectionGenerator;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArchitectureConfiguration;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator.RecommendationGenerator;
 import edu.kit.kastel.mcse.ardoco.tlr.text.providers.TextPreprocessingAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.textextraction.TextExtraction;
@@ -56,7 +56,7 @@ public class ArDoCoForInconsistencyDetection extends ArDoCoRunner {
         arDoCo.addPipelineStep(TextPreprocessingAgent.get(additionalConfigs, dataRepository));
         var architectureConfiguration = new ArchitectureConfiguration(inputArchitectureModel, modelFormat,
                 Metamodel.ARCHITECTURE_WITH_COMPONENTS_AND_INTERFACES);
-        ArCoTLModelProviderAgent arCoTLModelProviderAgent = ArCoTLModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs,
+        ModelProviderAgent arCoTLModelProviderAgent = ModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs,
                 architectureConfiguration, null);
         arDoCo.addPipelineStep(arCoTLModelProviderAgent);
         arDoCo.addPipelineStep(TextExtraction.get(additionalConfigs, dataRepository));

--- a/inconsistency-detection/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/id/tests/integration/inconsistencyhelper/HoldBackArCoTLModelProvider.java
+++ b/inconsistency-detection/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/id/tests/integration/inconsistencyhelper/HoldBackArCoTLModelProvider.java
@@ -16,10 +16,10 @@ import edu.kit.kastel.mcse.ardoco.core.api.models.Model;
 import edu.kit.kastel.mcse.ardoco.core.api.models.architecture.ArchitectureComponent;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.Extractor;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.pcm.PcmExtractor;
-import edu.kit.kastel.mcse.ardoco.tlr.models.informants.ArCoTLModelProviderInformant;
+import edu.kit.kastel.mcse.ardoco.tlr.models.informants.ModelProviderInformant;
 
 public class HoldBackArCoTLModelProvider {
 
@@ -72,7 +72,7 @@ public class HoldBackArCoTLModelProvider {
     }
 
     public PipelineAgent get(ImmutableSortedMap<String, String> additionalConfigs, DataRepository dataRepository) {
-        PipelineAgent agent = new PipelineAgent(List.of(new ArCoTLModelProviderInformant(dataRepository, new Extractor("", this.initialModel.getMetamodel()) {
+        PipelineAgent agent = new PipelineAgent(List.of(new ModelProviderInformant(dataRepository, new Extractor("", this.initialModel.getMetamodel()) {
 
             @Override
             public Model extractModel() {
@@ -81,7 +81,7 @@ public class HoldBackArCoTLModelProvider {
                 elements.remove(elementToRemove);
                 return new ArchitectureComponentModel(new ArchitectureModelWithComponentsAndInterfaces(new ArrayList<>(elements)));
             }
-        })), ArCoTLModelProviderAgent.class.getSimpleName(), dataRepository) {
+        })), ModelProviderAgent.class.getSimpleName(), dataRepository) {
 
             @Override
             protected void delegateApplyConfigurationToInternalObjects(ImmutableSortedMap<String, String> additionalConfiguration) {

--- a/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Arcotl.java
+++ b/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Arcotl.java
@@ -9,9 +9,9 @@ import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.execution.ArDoCo;
 import edu.kit.kastel.mcse.ardoco.core.execution.runner.ArDoCoRunner;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.SamCodeTraceabilityLinkRecovery;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArchitectureConfiguration;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.CodeConfiguration;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 
 /**
  * ArCoTL (Architecture-Code Trace Links) focuses on linking a given architecture model (SAM) to the source code. It assumes you have a formal model of the
@@ -41,11 +41,11 @@ public class Arcotl extends ArDoCoRunner {
         ArDoCo arDoCo = this.getArDoCo();
         var dataRepository = arDoCo.getDataRepository();
 
-        ArCoTLModelProviderAgent arCoTLModelProviderAgent = ArCoTLModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, //
+        ModelProviderAgent modelProviderAgent = ModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, //
                 architectureConfiguration.withMetamodel(Metamodel.ARCHITECTURE_WITH_COMPONENTS_AND_INTERFACES), //
                 codeConfiguration.withMetamodel(Metamodel.CODE_WITH_COMPILATION_UNITS) //
         );
-        arDoCo.addPipelineStep(arCoTLModelProviderAgent);
+        arDoCo.addPipelineStep(modelProviderAgent);
         arDoCo.addPipelineStep(SamCodeTraceabilityLinkRecovery.get(additionalConfigs, dataRepository));
     }
 }

--- a/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Ardocode.java
+++ b/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Ardocode.java
@@ -12,8 +12,8 @@ import edu.kit.kastel.mcse.ardoco.core.execution.ArDoCo;
 import edu.kit.kastel.mcse.ardoco.core.execution.runner.ArDoCoRunner;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.SadCodeTraceabilityLinkRecovery;
 import edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.ConnectionGenerator;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.CodeConfiguration;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator.RecommendationGenerator;
 import edu.kit.kastel.mcse.ardoco.tlr.text.providers.TextPreprocessingAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.textextraction.TextExtraction;
@@ -47,9 +47,9 @@ public class Ardocode extends ArDoCoRunner {
             throw new IllegalArgumentException("Cannot deal with empty input text. Maybe there was an error reading the file.");
         }
         DataRepositoryHelper.putInputText(dataRepository, text);
-        ArCoTLModelProviderAgent arCoTLModelProviderAgent = ArCoTLModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, null,
-                codeConfiguration.withMetamodel(Metamodel.CODE_WITH_COMPILATION_UNITS_AND_PACKAGES));
-        arDoCo.addPipelineStep(arCoTLModelProviderAgent);
+        ModelProviderAgent modelProviderAgent = ModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, null, codeConfiguration
+                .withMetamodel(Metamodel.CODE_WITH_COMPILATION_UNITS_AND_PACKAGES));
+        arDoCo.addPipelineStep(modelProviderAgent);
 
         arDoCo.addPipelineStep(TextPreprocessingAgent.get(additionalConfigs, dataRepository));
 

--- a/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Swattr.java
+++ b/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Swattr.java
@@ -10,8 +10,8 @@ import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 import edu.kit.kastel.mcse.ardoco.core.common.util.DataRepositoryHelper;
 import edu.kit.kastel.mcse.ardoco.core.execution.runner.ArDoCoRunner;
 import edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.ConnectionGenerator;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArchitectureConfiguration;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator.RecommendationGenerator;
 import edu.kit.kastel.mcse.ardoco.tlr.text.providers.TextPreprocessingAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.textextraction.TextExtraction;
@@ -52,10 +52,10 @@ public class Swattr extends ArDoCoRunner {
 
         this.getArDoCo().addPipelineStep(TextPreprocessingAgent.get(additionalConfigs, dataRepository));
 
-        ArCoTLModelProviderAgent arCoTLModelProviderAgent = //
-                ArCoTLModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, architectureConfiguration.withMetamodel(
+        ModelProviderAgent modelProviderAgent = //
+                ModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, architectureConfiguration.withMetamodel(
                         Metamodel.ARCHITECTURE_WITH_COMPONENTS), null);
-        this.getArDoCo().addPipelineStep(arCoTLModelProviderAgent);
+        this.getArDoCo().addPipelineStep(modelProviderAgent);
 
         this.getArDoCo().addPipelineStep(TextExtraction.get(additionalConfigs, dataRepository));
         this.getArDoCo().addPipelineStep(RecommendationGenerator.get(additionalConfigs, dataRepository));

--- a/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Transarc.java
+++ b/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/Transarc.java
@@ -13,9 +13,9 @@ import edu.kit.kastel.mcse.ardoco.core.execution.runner.ArDoCoRunner;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.SadSamCodeTraceabilityLinkRecovery;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.SamCodeTraceabilityLinkRecovery;
 import edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.ConnectionGenerator;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArchitectureConfiguration;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.CodeConfiguration;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator.RecommendationGenerator;
 import edu.kit.kastel.mcse.ardoco.tlr.text.providers.TextPreprocessingAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.textextraction.TextExtraction;
@@ -55,11 +55,11 @@ public class Transarc extends ArDoCoRunner {
 
         arDoCo.addPipelineStep(TextPreprocessingAgent.get(additionalConfigs, dataRepository));
 
-        ArCoTLModelProviderAgent arCoTLModelProviderAgent = ArCoTLModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs,
-                architectureConfiguration.withMetamodel(Metamodel.ARCHITECTURE_WITH_COMPONENTS), //
+        ModelProviderAgent modelProviderAgent = ModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, architectureConfiguration
+                .withMetamodel(Metamodel.ARCHITECTURE_WITH_COMPONENTS), //
                 codeConfiguration.withMetamodel(Metamodel.CODE_WITH_COMPILATION_UNITS) //
         );
-        arDoCo.addPipelineStep(arCoTLModelProviderAgent);
+        arDoCo.addPipelineStep(modelProviderAgent);
 
         arDoCo.addPipelineStep(TextExtraction.get(additionalConfigs, dataRepository));
         arDoCo.addPipelineStep(RecommendationGenerator.get(additionalConfigs, dataRepository));

--- a/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/TransarcAi.java
+++ b/tlr/pipeline-tlr/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/execution/TransarcAi.java
@@ -13,9 +13,9 @@ import edu.kit.kastel.mcse.ardoco.core.execution.runner.ArDoCoRunner;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.SadSamCodeTraceabilityLinkRecovery;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.SamCodeTraceabilityLinkRecovery;
 import edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.ConnectionGenerator;
-import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ArCoTLModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.CodeConfiguration;
 import edu.kit.kastel.mcse.ardoco.tlr.models.agents.LlmArchitectureProviderAgent;
+import edu.kit.kastel.mcse.ardoco.tlr.models.agents.ModelProviderAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.informants.LargeLanguageModel;
 import edu.kit.kastel.mcse.ardoco.tlr.models.informants.LlmArchitecturePrompt;
 import edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator.RecommendationGenerator;
@@ -60,8 +60,8 @@ public class TransarcAi extends ArDoCoRunner {
 
         arDoCo.addPipelineStep(TextPreprocessingAgent.get(additionalConfigs, dataRepository));
 
-        ArCoTLModelProviderAgent arCoTLModelProviderAgent = ArCoTLModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, null,
-                codeConfiguration.withMetamodel(Metamodel.CODE_WITH_COMPILATION_UNITS_AND_PACKAGES));
+        ModelProviderAgent arCoTLModelProviderAgent = ModelProviderAgent.getArCoTLModelProviderAgent(dataRepository, additionalConfigs, null, codeConfiguration
+                .withMetamodel(Metamodel.CODE_WITH_COMPILATION_UNITS_AND_PACKAGES));
         arDoCo.addPipelineStep(arCoTLModelProviderAgent);
 
         LlmArchitectureProviderAgent llmArchitectureProviderAgent = new LlmArchitectureProviderAgent(dataRepository, largeLanguageModel,

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/ModelProviderAgent.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/ModelProviderAgent.java
@@ -10,12 +10,12 @@ import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.PipelineAgent;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.Extractor;
-import edu.kit.kastel.mcse.ardoco.tlr.models.informants.ArCoTLModelProviderInformant;
+import edu.kit.kastel.mcse.ardoco.tlr.models.informants.ModelProviderInformant;
 
 /**
  * Agent that provides information from models.
  */
-public class ArCoTLModelProviderAgent extends PipelineAgent {
+public class ModelProviderAgent extends PipelineAgent {
 
     /**
      * Instantiates a new model provider agent. The constructor takes a list of ModelConnectors that are executed and used to extract information from models.
@@ -25,37 +25,37 @@ public class ArCoTLModelProviderAgent extends PipelineAgent {
      * @param architectureConfiguration the architecture configuration
      * @param codeConfiguration         the code configuration
      */
-    public ArCoTLModelProviderAgent(DataRepository data, ArchitectureConfiguration architectureConfiguration, CodeConfiguration codeConfiguration) {
-        super(informants(data, architectureConfiguration, codeConfiguration), ArCoTLModelProviderAgent.class.getSimpleName(), data);
+    public ModelProviderAgent(DataRepository data, ArchitectureConfiguration architectureConfiguration, CodeConfiguration codeConfiguration) {
+        super(informants(data, architectureConfiguration, codeConfiguration), ModelProviderAgent.class.getSimpleName(), data);
     }
 
     private static List<? extends Informant> informants(DataRepository data, ArchitectureConfiguration architectureConfiguration,
             CodeConfiguration codeConfiguration) {
         List<Informant> informants = new ArrayList<>();
         if (architectureConfiguration != null) {
-            informants.add(new ArCoTLModelProviderInformant(data, architectureConfiguration.extractor()));
+            informants.add(new ModelProviderInformant(data, architectureConfiguration.extractor()));
         }
 
         if (codeConfiguration != null && codeConfiguration.type() == CodeConfiguration.CodeConfigurationType.ACM_FILE) {
-            informants.add(new ArCoTLModelProviderInformant(data, codeConfiguration.code(), codeConfiguration.metamodel()));
+            informants.add(new ModelProviderInformant(data, codeConfiguration.code(), codeConfiguration.metamodel()));
         }
 
         if (codeConfiguration != null && codeConfiguration.type() == CodeConfiguration.CodeConfigurationType.DIRECTORY) {
             for (Extractor e : codeConfiguration.extractors()) {
-                informants.add(new ArCoTLModelProviderInformant(data, e));
+                informants.add(new ModelProviderInformant(data, e));
             }
         }
 
         return informants;
     }
 
-    public static ArCoTLModelProviderAgent getArCoTLModelProviderAgent(DataRepository dataRepository, ImmutableSortedMap<String, String> additionalConfigs,
+    public static ModelProviderAgent getArCoTLModelProviderAgent(DataRepository dataRepository, ImmutableSortedMap<String, String> additionalConfigs,
             ArchitectureConfiguration architectureConfiguration, CodeConfiguration codeConfiguration) {
         if (architectureConfiguration == null && codeConfiguration == null) {
             throw new IllegalArgumentException("At least one configuration must be provided");
         }
 
-        var agent = new ArCoTLModelProviderAgent(dataRepository, architectureConfiguration, codeConfiguration);
+        var agent = new ModelProviderAgent(dataRepository, architectureConfiguration, codeConfiguration);
         agent.applyConfiguration(additionalConfigs);
         return agent;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/informants/ModelProviderInformant.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/informants/ModelProviderInformant.java
@@ -20,14 +20,14 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.CodeExtr
 /**
  * The model extractor extracts the instances and relations via a connector. The extracted items are stored in a model extraction state.
  */
-public final class ArCoTLModelProviderInformant extends Informant {
+public final class ModelProviderInformant extends Informant {
     private static final String MODEL_STATES_DATA = "ModelStatesData";
     private final Extractor extractor;
     private final File fromFile;
     private final Metamodel metamodel;
 
     // Needed for Configuration Generation
-    private ArCoTLModelProviderInformant() {
+    private ModelProviderInformant() {
         super(null, null);
         this.extractor = null;
         this.fromFile = null;
@@ -40,7 +40,7 @@ public final class ArCoTLModelProviderInformant extends Informant {
      * @param dataRepository the data repository
      * @param fromFile       whether the model should be read from a file
      */
-    public ArCoTLModelProviderInformant(DataRepository dataRepository, File fromFile, Metamodel metamodel) {
+    public ModelProviderInformant(DataRepository dataRepository, File fromFile, Metamodel metamodel) {
         super("Extractor File", dataRepository);
         this.fromFile = Objects.requireNonNull(fromFile);
         this.metamodel = Objects.requireNonNull(metamodel);
@@ -53,7 +53,7 @@ public final class ArCoTLModelProviderInformant extends Informant {
      * @param dataRepository the data repository
      * @param extractor      the model connector
      */
-    public ArCoTLModelProviderInformant(DataRepository dataRepository, Extractor extractor) {
+    public ModelProviderInformant(DataRepository dataRepository, Extractor extractor) {
         super("Extractor " + (extractor == null ? "File" : extractor.getClass().getSimpleName()), dataRepository);
         this.extractor = extractor;
         this.fromFile = null;
@@ -83,13 +83,13 @@ public final class ArCoTLModelProviderInformant extends Informant {
 
     private void addModelStateToDataRepository(Metamodel metamodel, Model model) {
         var dataRepository = this.getDataRepository();
-        Optional<ModelStates> modelStatesOptional = dataRepository.getData(ArCoTLModelProviderInformant.MODEL_STATES_DATA, ModelStates.class);
+        Optional<ModelStates> modelStatesOptional = dataRepository.getData(ModelProviderInformant.MODEL_STATES_DATA, ModelStates.class);
         var modelStates = modelStatesOptional.orElseGet(ModelStates::new);
 
         modelStates.addModel(metamodel, model);
 
         if (modelStatesOptional.isEmpty()) {
-            dataRepository.addData(ArCoTLModelProviderInformant.MODEL_STATES_DATA, modelStates);
+            dataRepository.addData(ModelProviderInformant.MODEL_STATES_DATA, modelStates);
         }
     }
 


### PR DESCRIPTION
For ardoco v2, we only have one model provider left. 