### PR TITLE
Include start and end line numbers in code model

### DIFF
--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModel.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModel.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models;
 
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public abstract sealed class CodeModel extends Model permits CodeModelWithCompil
      * @return code model DTO
      */
     public CodeModelDto createCodeModelDto() {
-        return new CodeModelDto(codeItemRepository, getContentIds());
+        return new CodeModelDto(getId(), codeItemRepository, getContentIds());
     }
 
     private List<String> getContentIds() {
@@ -109,7 +109,7 @@ public abstract sealed class CodeModel extends Model permits CodeModelWithCompil
      * @param codeItemRepository the repository of code items
      * @param content            the list of content identifiers
      */
-    public record CodeModelDto(@JsonProperty CodeItemRepository codeItemRepository, @JsonProperty List<String> content) {
+    public record CodeModelDto(@JsonProperty String id, @JsonProperty CodeItemRepository codeItemRepository, @JsonProperty List<String> content) {
         /**
          * Returns the code item repository, initializing it if necessary.
          *

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModel.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModel.java
@@ -39,6 +39,20 @@ public abstract sealed class CodeModel extends Model permits CodeModelWithCompil
     }
 
     /**
+     * Creates a new code model with the specified id, code item repository, and content IDs.
+     *
+     * @param id                 the model id
+     * @param codeItemRepository the code item repository
+     * @param content            list of code item IDs
+     */
+    protected CodeModel(String id, CodeItemRepository codeItemRepository, List<String> content) {
+        super(id);
+        this.initialized = true;
+        this.codeItemRepository = codeItemRepository;
+        this.content = new ArrayList<>(content);
+    }
+
+    /**
      * Creates a new code model with the specified code item repository and content.
      *
      * @param codeItemRepository the code item repository
@@ -106,6 +120,7 @@ public abstract sealed class CodeModel extends Model permits CodeModelWithCompil
     /**
      * Data transfer object for the code model. Contains a {@link CodeItemRepository} and a list of content identifiers.
      *
+     * @param id                 the model id
      * @param codeItemRepository the repository of code items
      * @param content            the list of content identifiers
      */

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModelWithCompilationUnits.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModelWithCompilationUnits.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models;
 
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ public final class CodeModelWithCompilationUnits extends CodeModel {
      * @param codeModelDto the code model Dto
      */
     public CodeModelWithCompilationUnits(CodeModelDto codeModelDto) {
-        super(codeModelDto.codeItemRepository(), codeModelDto.content());
+        super(codeModelDto.id(), codeModelDto.codeItemRepository(), codeModelDto.content());
     }
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModelWithCompilationUnitsAndPackages.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/CodeModelWithCompilationUnitsAndPackages.java
@@ -23,7 +23,7 @@ public final class CodeModelWithCompilationUnitsAndPackages extends CodeModel {
      * @param codeModelDto the code model Dto
      */
     public CodeModelWithCompilationUnitsAndPackages(CodeModelDto codeModelDto) {
-        super(codeModelDto.codeItemRepository(), codeModelDto.content());
+        super(codeModelDto.id(), codeModelDto.codeItemRepository(), codeModelDto.content());
         this.codeModel = new CodeModelWithCompilationUnits(codeModelDto);
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/Model.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/Model.java
@@ -27,7 +27,7 @@ public abstract sealed class Model permits ArchitectureModel, CodeModel {
      * @param id the model id
      */
     protected Model(String id) {
-        this.id = id;
+        this.id = id != null ? id : IdentifierProvider.createId();
     }
 
     public String getId() {

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/Model.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/Model.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models;
 
 import java.util.List;
@@ -12,7 +12,23 @@ import edu.kit.kastel.mcse.ardoco.core.common.IdentifierProvider;
  */
 public abstract sealed class Model permits ArchitectureModel, CodeModel {
 
-    private final String id = IdentifierProvider.createId();
+    private final String id;
+
+    /**
+     * Creates a new model with a generated id.
+     */
+    protected Model() {
+        this.id = IdentifierProvider.createId();
+    }
+
+    /**
+     * Creates a new model with the specified id.
+     *
+     * @param id the model id
+     */
+    protected Model(String id) {
+        this.id = id;
+    }
 
     public String getId() {
         return this.id;

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ClassUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ClassUnit.java
@@ -2,12 +2,8 @@
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.SortedSet;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /**
@@ -19,16 +15,12 @@ public final class ClassUnit extends Datatype {
     @Serial
     private static final long serialVersionUID = 354013115794534271L;
 
-    @JsonProperty
-    private final List<String> content;
-
     /**
      * Default constructor for Jackson.
      */
     @SuppressWarnings("unused")
     private ClassUnit() {
         // Jackson
-        this.content = new ArrayList<>();
     }
 
     /**
@@ -39,11 +31,7 @@ public final class ClassUnit extends Datatype {
      * @param content            the content of the class unit
      */
     public ClassUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content) {
-        super(codeItemRepository, name);
-        this.content = new ArrayList<>();
-        for (var codeItem : content) {
-            this.content.add(codeItem.getId());
-        }
+        super(codeItemRepository, name, content);
     }
 
     /**
@@ -56,46 +44,7 @@ public final class ClassUnit extends Datatype {
      * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
      */
     public ClassUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, int startLine, int endLine) {
-        super(codeItemRepository, name, startLine, endLine);
-        this.content = new ArrayList<>();
-        for (var codeItem : content) {
-            this.content.add(codeItem.getId());
-        }
-    }
-
-    /**
-     * Returns the content IDs of this class unit.
-     *
-     * @return list of content IDs
-     */
-    @JsonGetter("content")
-    public List<String> getContentIds() {
-        return new ArrayList<>(this.content);
-    }
-
-    /**
-     * Returns the content of this class unit as a list of code items.
-     *
-     * @return list of code items
-     */
-    @Override
-    public List<CodeItem> getContent() {
-        return this.codeItemRepository.getCodeItemsByIds(this.content);
-    }
-
-    /**
-     * Returns all datatypes contained in this class unit, including itself and all nested datatypes.
-     *
-     * @return list of all datatypes
-     */
-    @Override
-    public List<Datatype> getAllDataTypes() {
-        List<Datatype> result = new ArrayList<>();
-        result.add(this);
-        for (CodeItem codeItem : this.getContent()) {
-            result.addAll(codeItem.getAllDataTypes());
-        }
-        return result;
+        super(codeItemRepository, name, content, startLine, endLine);
     }
 
     @Override
@@ -103,15 +52,6 @@ public final class ClassUnit extends Datatype {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ClassUnit classUnit) || !super.equals(o)) {
-            return false;
-        }
-        return this.content.equals(classUnit.content);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        return 31 * result + this.content.hashCode();
+        return o instanceof ClassUnit && super.equals(o);
     }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ClassUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ClassUnit.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -40,6 +40,23 @@ public final class ClassUnit extends Datatype {
      */
     public ClassUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content) {
         super(codeItemRepository, name);
+        this.content = new ArrayList<>();
+        for (var codeItem : content) {
+            this.content.add(codeItem.getId());
+        }
+    }
+
+    /**
+     * Creates a new class unit with the specified name, content, and source location.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the class unit
+     * @param content            the content of the class unit
+     * @param startLine          the 1-indexed start line in the source file, or -1 if unknown
+     * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
+     */
+    public ClassUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, int startLine, int endLine) {
+        super(codeItemRepository, name, startLine, endLine);
         this.content = new ArrayList<>();
         for (var codeItem : content) {
             this.content.add(codeItem.getId());

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
@@ -70,4 +70,22 @@ public final class ControlElement extends ComputationalObject {
     public int getEndLine() {
         return endLine;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ControlElement that) || !super.equals(o)) {
+            return false;
+        }
+        return this.startLine == that.startLine && this.endLine == that.endLine;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + this.startLine;
+        return 31 * result + this.endLine;
+    }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
@@ -1,8 +1,9 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /**
@@ -14,6 +15,11 @@ public final class ControlElement extends ComputationalObject {
 
     @Serial
     private static final long serialVersionUID = -2733651783905632198L;
+
+    @JsonProperty
+    private int startLine = -1;
+    @JsonProperty
+    private int endLine = -1;
 
     /**
      * Default constructor for Jackson.
@@ -31,5 +37,37 @@ public final class ControlElement extends ComputationalObject {
      */
     public ControlElement(CodeItemRepository codeItemRepository, String name) {
         super(codeItemRepository, name);
+    }
+
+    /**
+     * Creates a new control element with the specified name and source location.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the control element
+     * @param startLine          the 1-indexed start line in the source file, or -1 if unknown
+     * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
+     */
+    public ControlElement(CodeItemRepository codeItemRepository, String name, int startLine, int endLine) {
+        super(codeItemRepository, name);
+        this.startLine = startLine;
+        this.endLine = endLine;
+    }
+
+    /**
+     * Returns the 1-indexed start line of this element in its source file, or -1 if unknown.
+     *
+     * @return the start line
+     */
+    public int getStartLine() {
+        return startLine;
+    }
+
+    /**
+     * Returns the 1-indexed end line of this element in its source file, or -1 if unknown.
+     *
+     * @return the end line
+     */
+    public int getEndLine() {
+        return endLine;
     }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
@@ -9,6 +9,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -42,6 +43,8 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
     private List<String> implementedDataTypesIds;
     @JsonProperty
     private List<String> datatypeReferencesIds;
+    @JsonProperty
+    private List<String> content;
 
     Datatype() {
         // Jackson
@@ -52,12 +55,17 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
      *
      * @param codeItemRepository the code item repository
      * @param name               the name of the datatype
+     * @param content            the content of the datatype
      */
-    public Datatype(CodeItemRepository codeItemRepository, String name) {
+    public Datatype(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content) {
         super(codeItemRepository, name);
         this.extendedDataTypesIds = new ArrayList<>();
         this.implementedDataTypesIds = new ArrayList<>();
         this.datatypeReferencesIds = new ArrayList<>();
+        this.content = new ArrayList<>();
+        for (var codeItem : content) {
+            this.content.add(codeItem.getId());
+        }
     }
 
     /**
@@ -65,11 +73,12 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
      *
      * @param codeItemRepository the code item repository
      * @param name               the name of the datatype
+     * @param content            the content of the datatype
      * @param startLine          the 1-indexed start line in the source file, or -1 if unknown
      * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
      */
-    public Datatype(CodeItemRepository codeItemRepository, String name, int startLine, int endLine) {
-        this(codeItemRepository, name);
+    public Datatype(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, int startLine, int endLine) {
+        this(codeItemRepository, name, content);
         this.startLine = startLine;
         this.endLine = endLine;
     }
@@ -167,6 +176,41 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
     }
 
     /**
+     * Returns the content of this datatype as a list of code items.
+     *
+     * @return list of code items
+     */
+    @Override
+    public List<CodeItem> getContent() {
+        return this.codeItemRepository.getCodeItemsByIds(this.content);
+    }
+
+    /**
+     * Returns the content IDs of this datatype.
+     *
+     * @return list of content IDs
+     */
+    @JsonGetter("content")
+    public List<String> getContentIds() {
+        return new ArrayList<>(this.content);
+    }
+
+    /**
+     * Returns all data types contained in this datatype.
+     *
+     * @return list of all data types
+     */
+    @Override
+    public List<Datatype> getAllDataTypes() {
+        List<Datatype> result = new ArrayList<>();
+        result.add(this);
+        for (CodeItem codeItem : this.getContent()) {
+            result.addAll(codeItem.getAllDataTypes());
+        }
+        return result;
+    }
+
+    /**
      * Sets the compilation unit for this datatype.
      *
      * @param compilationUnit the compilation unit to set
@@ -232,7 +276,10 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
         if (!Objects.equals(this.implementedDataTypesIds, datatype.implementedDataTypesIds)) {
             return false;
         }
-        return Objects.equals(this.datatypeReferencesIds, datatype.datatypeReferencesIds);
+        if (!Objects.equals(this.datatypeReferencesIds, datatype.datatypeReferencesIds)) {
+            return false;
+        }
+        return Objects.equals(this.content, datatype.content);
     }
 
     @Override
@@ -244,6 +291,7 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
         result = 31 * result + this.endLine;
         result = 31 * result + (this.extendedDataTypesIds != null ? this.extendedDataTypesIds.hashCode() : 0);
         result = 31 * result + (this.implementedDataTypesIds != null ? this.implementedDataTypesIds.hashCode() : 0);
-        return 31 * result + (this.datatypeReferencesIds != null ? this.datatypeReferencesIds.hashCode() : 0);
+        result = 31 * result + (this.datatypeReferencesIds != null ? this.datatypeReferencesIds.hashCode() : 0);
+        return 31 * result + (this.content != null ? this.content.hashCode() : 0);
     }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
@@ -223,7 +223,7 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
             return true;
         }
         if (!(o instanceof Datatype datatype) || !super.equals(o) || !Objects.equals(this.compilationUnitId, datatype.compilationUnitId) || !Objects.equals(
-                this.parentDatatypeId, datatype.parentDatatypeId)) {
+                this.parentDatatypeId, datatype.parentDatatypeId) || this.startLine != datatype.startLine || this.endLine != datatype.endLine) {
             return false;
         }
         if (!Objects.equals(this.extendedDataTypesIds, datatype.extendedDataTypesIds)) {
@@ -240,6 +240,8 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
         int result = super.hashCode();
         result = 31 * result + (this.compilationUnitId != null ? this.compilationUnitId.hashCode() : 0);
         result = 31 * result + (this.parentDatatypeId != null ? this.parentDatatypeId.hashCode() : 0);
+        result = 31 * result + this.startLine;
+        result = 31 * result + this.endLine;
         result = 31 * result + (this.extendedDataTypesIds != null ? this.extendedDataTypesIds.hashCode() : 0);
         result = 31 * result + (this.implementedDataTypesIds != null ? this.implementedDataTypesIds.hashCode() : 0);
         return 31 * result + (this.datatypeReferencesIds != null ? this.datatypeReferencesIds.hashCode() : 0);

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -33,6 +33,10 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
     @JsonProperty
     private String parentDatatypeId;
     @JsonProperty
+    private int startLine = -1;
+    @JsonProperty
+    private int endLine = -1;
+    @JsonProperty
     private List<String> extendedDataTypesIds;
     @JsonProperty
     private List<String> implementedDataTypesIds;
@@ -54,6 +58,38 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
         this.extendedDataTypesIds = new ArrayList<>();
         this.implementedDataTypesIds = new ArrayList<>();
         this.datatypeReferencesIds = new ArrayList<>();
+    }
+
+    /**
+     * Creates a new datatype with the specified name and source location.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the datatype
+     * @param startLine          the 1-indexed start line in the source file, or -1 if unknown
+     * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
+     */
+    public Datatype(CodeItemRepository codeItemRepository, String name, int startLine, int endLine) {
+        this(codeItemRepository, name);
+        this.startLine = startLine;
+        this.endLine = endLine;
+    }
+
+    /**
+     * Returns the 1-indexed start line of this datatype in its source file, or -1 if unknown.
+     *
+     * @return the start line
+     */
+    public int getStartLine() {
+        return startLine;
+    }
+
+    /**
+     * Returns the 1-indexed end line of this datatype in its source file, or -1 if unknown.
+     *
+     * @return the end line
+     */
+    public int getEndLine() {
+        return endLine;
     }
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/InterfaceUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/InterfaceUnit.java
@@ -2,13 +2,8 @@
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import java.util.SortedSet;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /**
@@ -19,9 +14,6 @@ public final class InterfaceUnit extends Datatype {
 
     @Serial
     private static final long serialVersionUID = 7746781256077022392L;
-
-    @JsonProperty
-    private List<String> content;
 
     @SuppressWarnings("unused")
     private InterfaceUnit() {
@@ -36,11 +28,7 @@ public final class InterfaceUnit extends Datatype {
      * @param content            the content of the interface unit
      */
     public InterfaceUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content) {
-        super(codeItemRepository, name);
-        this.content = new ArrayList<>();
-        for (var codeItem : content) {
-            this.content.add(codeItem.getId());
-        }
+        super(codeItemRepository, name, content);
     }
 
     /**
@@ -53,46 +41,7 @@ public final class InterfaceUnit extends Datatype {
      * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
      */
     public InterfaceUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, int startLine, int endLine) {
-        super(codeItemRepository, name, startLine, endLine);
-        this.content = new ArrayList<>();
-        for (var codeItem : content) {
-            this.content.add(codeItem.getId());
-        }
-    }
-
-    /**
-     * Returns the content IDs of this interface unit.
-     *
-     * @return list of content IDs
-     */
-    @JsonGetter("content")
-    public List<String> getContentIds() {
-        return new ArrayList<>(this.content);
-    }
-
-    /**
-     * Returns the content of this interface unit as a list of code items.
-     *
-     * @return list of code items
-     */
-    @Override
-    public List<CodeItem> getContent() {
-        return this.codeItemRepository.getCodeItemsByIds(this.content);
-    }
-
-    /**
-     * Returns all data types contained in this interface unit.
-     *
-     * @return list of all data types
-     */
-    @Override
-    public List<Datatype> getAllDataTypes() {
-        List<Datatype> result = new ArrayList<>();
-        result.add(this);
-        for (CodeItem codeItem : this.getContent()) {
-            result.addAll(codeItem.getAllDataTypes());
-        }
-        return result;
+        super(codeItemRepository, name, content, startLine, endLine);
     }
 
     @Override
@@ -100,16 +49,6 @@ public final class InterfaceUnit extends Datatype {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof InterfaceUnit that) || !super.equals(o)) {
-            return false;
-        }
-
-        return Objects.equals(this.content, that.content);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        return 31 * result + (this.content != null ? this.content.hashCode() : 0);
+        return o instanceof InterfaceUnit && super.equals(o);
     }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/InterfaceUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/InterfaceUnit.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -37,6 +37,23 @@ public final class InterfaceUnit extends Datatype {
      */
     public InterfaceUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content) {
         super(codeItemRepository, name);
+        this.content = new ArrayList<>();
+        for (var codeItem : content) {
+            this.content.add(codeItem.getId());
+        }
+    }
+
+    /**
+     * Creates a new interface unit with the specified name, content, and source location.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the interface unit
+     * @param content            the content of the interface unit
+     * @param startLine          the 1-indexed start line in the source file, or -1 if unknown
+     * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
+     */
+    public InterfaceUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, int startLine, int endLine) {
+        super(codeItemRepository, name, startLine, endLine);
         this.content = new ArrayList<>();
         for (var codeItem : content) {
             this.content.add(codeItem.getId());

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/ClassMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/ClassMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.cpp.mappers;
 
 import java.util.SortedSet;
@@ -37,7 +37,7 @@ public class ClassMapper extends AbstractCppCodeItemMapper {
         ClassElement classElement = this.elementRegistry.getClass(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
 
-        ClassUnit classUnit = new ClassUnit(this.codeItemRepository, classElement.getName(), content);
+        ClassUnit classUnit = new ClassUnit(this.codeItemRepository, classElement.getName(), content, classElement.getStartLine(), classElement.getEndLine());
         classUnit.setComment(classElement.getComment());
         return classUnit;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FunctionMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.cpp.mappers;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
@@ -33,7 +33,7 @@ public class FunctionMapper extends AbstractCppCodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/ClassMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/ClassMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.java.mappers;
 
 import java.util.SortedSet;
@@ -37,7 +37,7 @@ public class ClassMapper extends AbstractJavaCodeItemMapper {
         JavaClassElement classElement = elementRegistry.getClass(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
 
-        ClassUnit classUnit = new ClassUnit(codeItemRepository, classElement.getName(), content);
+        ClassUnit classUnit = new ClassUnit(codeItemRepository, classElement.getName(), content, classElement.getStartLine(), classElement.getEndLine());
         classUnit.setComment(classElement.getComment());
         return classUnit;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/FunctionMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.java.mappers;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
@@ -33,7 +33,7 @@ public class FunctionMapper extends AbstractJavaCodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/InterfaceMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/InterfaceMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.java.mappers;
 
 import java.util.SortedSet;
@@ -37,7 +37,8 @@ public class InterfaceMapper extends AbstractJavaCodeItemMapper {
         Element interfaceElement = elementRegistry.getInterface(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
 
-        InterfaceUnit interfaceUnit = new InterfaceUnit(codeItemRepository, interfaceElement.getName(), content);
+        InterfaceUnit interfaceUnit = new InterfaceUnit(codeItemRepository, interfaceElement.getName(), content, interfaceElement.getStartLine(),
+                interfaceElement.getEndLine());
         interfaceUnit.setComment(interfaceElement.getComment());
         return interfaceUnit;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/ClassMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/ClassMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.python3.mappers;
 
 import java.util.SortedSet;
@@ -37,7 +37,7 @@ public class ClassMapper extends AbstractPython3CodeItemMapper {
         ClassElement classElement = elementRegistry.getClass(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
 
-        ClassUnit classUnit = new ClassUnit(codeItemRepository, classElement.getName(), content);
+        ClassUnit classUnit = new ClassUnit(codeItemRepository, classElement.getName(), content, classElement.getStartLine(), classElement.getEndLine());
         classUnit.setComment(classElement.getComment());
         return classUnit;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/FunctionMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.python3.mappers;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
@@ -34,7 +34,7 @@ public class FunctionMapper extends AbstractPython3CodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.java;
 
 import java.nio.file.Path;
@@ -221,11 +221,11 @@ public final class JavaModel {
         Map<ASTNode, Datatype> codeTypes = new LinkedHashMap<>();
         Set<TypeDeclaration> typeDeclarations = TypeDeclarationFinder.find(compilationUnit);
         for (TypeDeclaration typeDeclaration : typeDeclarations) {
-            codeTypes.put(typeDeclaration, processTypeDeclaration(typeDeclaration));
+            codeTypes.put(typeDeclaration, processTypeDeclaration(typeDeclaration, compilationUnit));
         }
         Set<EnumDeclaration> enumDeclarations = EnumDeclarationFinder.find(compilationUnit);
         for (EnumDeclaration enumDeclaration : enumDeclarations) {
-            codeTypes.put(enumDeclaration, processEnumDeclaration(enumDeclaration));
+            codeTypes.put(enumDeclaration, processEnumDeclaration(enumDeclaration, compilationUnit));
         }
         for (var entry : codeTypes.entrySet()) {
             ASTNode node = entry.getKey();
@@ -237,41 +237,47 @@ public final class JavaModel {
         return codeTypes.values().stream().toList();
     }
 
-    private ClassUnit processEnumDeclaration(EnumDeclaration enumDeclaration) {
+    private ClassUnit processEnumDeclaration(EnumDeclaration enumDeclaration, CompilationUnit compilationUnit) {
         String name = enumDeclaration.getName().getIdentifier();
-        SortedSet<ControlElement> declaredMethods = extractMethods(enumDeclaration);
-        ClassUnit codeClassifier = new ClassUnit(codeItemRepository, name, declaredMethods);
+        SortedSet<ControlElement> declaredMethods = extractMethods(enumDeclaration, compilationUnit);
+        int startLine = compilationUnit.getLineNumber(enumDeclaration.getStartPosition());
+        int endLine = compilationUnit.getLineNumber(enumDeclaration.getStartPosition() + enumDeclaration.getLength());
+        ClassUnit codeClassifier = new ClassUnit(codeItemRepository, name, declaredMethods, startLine, endLine);
         addClassifier(codeClassifier, enumDeclaration);
         return codeClassifier;
     }
 
-    private Datatype processTypeDeclaration(TypeDeclaration typeDeclaration) {
+    private Datatype processTypeDeclaration(TypeDeclaration typeDeclaration, CompilationUnit compilationUnit) {
         String name = typeDeclaration.getName().getIdentifier();
-        SortedSet<ControlElement> declaredMethods = extractMethods(typeDeclaration);
+        SortedSet<ControlElement> declaredMethods = extractMethods(typeDeclaration, compilationUnit);
+        int startLine = compilationUnit.getLineNumber(typeDeclaration.getStartPosition());
+        int endLine = compilationUnit.getLineNumber(typeDeclaration.getStartPosition() + typeDeclaration.getLength());
         Datatype codeType;
         if (typeDeclaration.isInterface()) {
-            InterfaceUnit codeInterface = new InterfaceUnit(codeItemRepository, name, declaredMethods);
+            InterfaceUnit codeInterface = new InterfaceUnit(codeItemRepository, name, declaredMethods, startLine, endLine);
             addInterface(codeInterface, typeDeclaration);
             codeType = codeInterface;
         } else {
-            ClassUnit classifier = new ClassUnit(codeItemRepository, name, declaredMethods);
+            ClassUnit classifier = new ClassUnit(codeItemRepository, name, declaredMethods, startLine, endLine);
             addClassifier(classifier, typeDeclaration);
             codeType = classifier;
         }
         return codeType;
     }
 
-    private SortedSet<ControlElement> extractMethods(ASTNode node) {
+    private SortedSet<ControlElement> extractMethods(ASTNode node, CompilationUnit compilationUnit) {
         SortedSet<ControlElement> declaredMethods = new TreeSet<>();
         Set<MethodDeclaration> methodDeclarations = MethodDeclarationFinder.find(node);
         for (MethodDeclaration methodDeclaration : methodDeclarations) {
-            declaredMethods.add(extractMethod(methodDeclaration));
+            declaredMethods.add(extractMethod(methodDeclaration, compilationUnit));
         }
         return declaredMethods;
     }
 
-    private ControlElement extractMethod(MethodDeclaration methodDeclaration) {
-        return new ControlElement(codeItemRepository, methodDeclaration.getName().getIdentifier());
+    private ControlElement extractMethod(MethodDeclaration methodDeclaration, CompilationUnit compilationUnit) {
+        int startLine = compilationUnit.getLineNumber(methodDeclaration.getStartPosition());
+        int endLine = compilationUnit.getLineNumber(methodDeclaration.getStartPosition() + methodDeclaration.getLength());
+        return new ControlElement(codeItemRepository, methodDeclaration.getName().getIdentifier(), startLine, endLine);
     }
 
     private static List<String> getPackageNames(Name name) {


### PR DESCRIPTION
For ML applications, it might be useful to know the location of specific elements like `ControlElement`, `ClassUnit`, and `InterfaceUnit`. In the ANTLR4 implementation, the foundation had already been laid. This PR integrates `startLine` and `endLine` into the code model serialization:

- Extraction of start and end lines in `JavaModel`
- Adding a new constructor for `Datatype` (and downstream `ClassUnit` and `InterfaceUnit`) and `ControlElement`
- Add the id of the top-level code item to serialization
- Complete the wiring of start and end line numbers also in the ANTLR4 package