### PR TITLE
File imports and function calls in code model

### DIFF
--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
@@ -70,7 +70,7 @@ public final class CodeAssembly extends CodeModule {
             List<String> importedModuleNames) {
         super(codeItemRepository, name, content);
         this.language = language;
-        this.importedModuleNames = new ArrayList<>(importedModuleNames);
+        this.importedModuleNames = importedModuleNames != null ? new ArrayList<>(importedModuleNames) : new ArrayList<>();
     }
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
@@ -2,6 +2,8 @@
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.SortedSet;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,6 +21,15 @@ public final class CodeAssembly extends CodeModule {
 
     @JsonProperty
     private String language;
+
+    @JsonProperty
+    private List<String> pathElements;
+
+    @JsonProperty
+    private String extension;
+
+    @JsonProperty
+    private List<String> importedModuleNames;
 
     /**
      * Default constructor for Jackson.
@@ -44,7 +55,66 @@ public final class CodeAssembly extends CodeModule {
         this.language = language;
     }
 
+    /**
+     * Constructs a new CodeAssembly with language and file path information.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the assembly
+     * @param content            the content of the assembly
+     * @param language           the programming language
+     * @param pathElements       the directory path segments leading to this file
+     * @param extension          the file extension (without leading dot)
+     */
+    public CodeAssembly(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, String language, List<String> pathElements,
+            String extension, List<String> importedModuleNames) {
+        super(codeItemRepository, name, content);
+        this.language = language;
+        this.pathElements = new ArrayList<>(pathElements);
+        this.extension = extension;
+        this.importedModuleNames = new ArrayList<>(importedModuleNames);
+    }
+
     public String getLanguage() {
         return language;
+    }
+
+    /**
+     * Returns the directory path segments of this assembly.
+     * Returns an empty list for structural assemblies (e.g. C++ namespaces) that have no file path.
+     * Use {@link #hasFilePath()} to distinguish the two cases.
+     *
+     * @return copy of the path elements list
+     */
+    public List<String> getPathElements() {
+        return this.pathElements != null ? new ArrayList<>(this.pathElements) : List.of();
+    }
+
+    /**
+     * Returns the file extension of this assembly.
+     * Returns an empty string for structural assemblies that have no file path.
+     * Use {@link #hasFilePath()} to distinguish the two cases.
+     *
+     * @return the file extension without leading dot
+     */
+    public String getExtension() {
+        return this.extension != null ? this.extension : "";
+    }
+
+    /**
+     * Returns whether this assembly corresponds to a source file (has path information).
+     *
+     * @return true if path elements are present
+     */
+    public boolean hasFilePath() {
+        return this.pathElements != null;
+    }
+
+    /**
+     * Returns the list of imported module/package names for this assembly (file-level imports).
+     *
+     * @return list of imported module names
+     */
+    public List<String> getImportedModuleNames() {
+        return this.importedModuleNames != null ? new ArrayList<>(this.importedModuleNames) : List.of();
     }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -23,12 +23,6 @@ public final class CodeAssembly extends CodeModule {
     private String language;
 
     @JsonProperty
-    private List<String> pathElements;
-
-    @JsonProperty
-    private String extension;
-
-    @JsonProperty
     private List<String> importedModuleNames;
 
     /**
@@ -50,63 +44,42 @@ public final class CodeAssembly extends CodeModule {
         super(codeItemRepository, name, content);
     }
 
+    /**
+     * Constructs a new CodeAssembly with language information.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the assembly
+     * @param content            the content of the assembly
+     * @param language           the programming language
+     */
     public CodeAssembly(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, String language) {
         super(codeItemRepository, name, content);
         this.language = language;
     }
 
     /**
-     * Constructs a new CodeAssembly with language and file path information.
+     * Constructs a new CodeAssembly with language, file path, and import information.
      *
-     * @param codeItemRepository the code item repository
-     * @param name               the name of the assembly
-     * @param content            the content of the assembly
-     * @param language           the programming language
-     * @param pathElements       the directory path segments leading to this file
-     * @param extension          the file extension (without leading dot)
+     * @param codeItemRepository  the code item repository
+     * @param name                the name of the assembly
+     * @param content             the content of the assembly
+     * @param language            the programming language
+     * @param importedModuleNames the names of imported modules declared in this assembly
      */
-    public CodeAssembly(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, String language, List<String> pathElements,
-            String extension, List<String> importedModuleNames) {
+    public CodeAssembly(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, String language,
+            List<String> importedModuleNames) {
         super(codeItemRepository, name, content);
         this.language = language;
-        this.pathElements = new ArrayList<>(pathElements);
-        this.extension = extension;
         this.importedModuleNames = new ArrayList<>(importedModuleNames);
     }
 
+    /**
+     * Returns the programming language of this assembly.
+     *
+     * @return the language string
+     */
     public String getLanguage() {
         return language;
-    }
-
-    /**
-     * Returns the directory path segments of this assembly.
-     * Returns an empty list for structural assemblies (e.g. C++ namespaces) that have no file path.
-     * Use {@link #hasFilePath()} to distinguish the two cases.
-     *
-     * @return copy of the path elements list
-     */
-    public List<String> getPathElements() {
-        return this.pathElements != null ? new ArrayList<>(this.pathElements) : List.of();
-    }
-
-    /**
-     * Returns the file extension of this assembly.
-     * Returns an empty string for structural assemblies that have no file path.
-     * Use {@link #hasFilePath()} to distinguish the two cases.
-     *
-     * @return the file extension without leading dot
-     */
-    public String getExtension() {
-        return this.extension != null ? this.extension : "";
-    }
-
-    /**
-     * Returns whether this assembly corresponds to a source file (has path information).
-     *
-     * @return true if path elements are present
-     */
-    public boolean hasFilePath() {
-        return this.pathElements != null;
     }
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
@@ -58,7 +58,7 @@ public final class CodeAssembly extends CodeModule {
     }
 
     /**
-     * Constructs a new CodeAssembly with language, file path, and import information.
+     * Constructs a new CodeAssembly with language, and import information.
      *
      * @param codeItemRepository  the code item repository
      * @param name                the name of the assembly

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
@@ -41,12 +41,13 @@ public final class CodeCompilationUnit extends CodeModule {
     /**
      * Creates a new CodeCompilationUnit.
      *
-     * @param codeItemRepository the code item repository
-     * @param name               the name of the compilation unit
-     * @param content            the content of the compilation unit
-     * @param pathElements       the path elements
-     * @param extension          the file extension
-     * @param language           the programming language
+     * @param codeItemRepository  the code item repository
+     * @param name                the name of the compilation unit
+     * @param content             the content of the compilation unit
+     * @param pathElements        the path elements
+     * @param extension           the file extension
+     * @param language            the programming language
+     * @param importedModuleNames the names of imported modules declared in this compilation unit
      */
     public CodeCompilationUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, List<String> pathElements,
             String extension, ProgrammingLanguage language, List<String> importedModuleNames) {
@@ -54,7 +55,7 @@ public final class CodeCompilationUnit extends CodeModule {
         this.pathElements = new ArrayList<>(pathElements);
         this.extension = extension;
         this.language = language;
-        this.importedModuleNames = importedModuleNames;
+        this.importedModuleNames = new ArrayList<>(importedModuleNames);
     }
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -27,6 +27,8 @@ public final class CodeCompilationUnit extends CodeModule {
     private String extension;
     @JsonProperty
     private ProgrammingLanguage language;
+    @JsonProperty
+    private List<String> importedModuleNames;
 
     /**
      * Default constructor for Jackson.
@@ -47,11 +49,12 @@ public final class CodeCompilationUnit extends CodeModule {
      * @param language           the programming language
      */
     public CodeCompilationUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, List<String> pathElements,
-            String extension, ProgrammingLanguage language) {
+            String extension, ProgrammingLanguage language, List<String> importedModuleNames) {
         super(codeItemRepository, name, content);
         this.pathElements = new ArrayList<>(pathElements);
         this.extension = extension;
         this.language = language;
+        this.importedModuleNames = importedModuleNames;
     }
 
     /**
@@ -113,6 +116,15 @@ public final class CodeCompilationUnit extends CodeModule {
      */
     public List<String> getPathElements() {
         return new ArrayList<>(this.pathElements);
+    }
+
+    /**
+     * Returns the list of imported module/package names for this compilation unit.
+     *
+     * @return list of imported module names
+     */
+    public List<String> getImportedModuleNames() {
+        return this.importedModuleNames != null ? new ArrayList<>(this.importedModuleNames) : List.of();
     }
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
@@ -55,7 +55,7 @@ public final class CodeCompilationUnit extends CodeModule {
         this.pathElements = new ArrayList<>(pathElements);
         this.extension = extension;
         this.language = language;
-        this.importedModuleNames = new ArrayList<>(importedModuleNames);
+        this.importedModuleNames = importedModuleNames != null ? new ArrayList<>(importedModuleNames) : new ArrayList<>();
     }
 
     /**
@@ -185,7 +185,7 @@ public final class CodeCompilationUnit extends CodeModule {
             return true;
         }
         if (!(o instanceof CodeCompilationUnit that) || !super.equals(o) || !Objects.equals(this.pathElements, that.pathElements) || !Objects.equals(
-                this.extension, that.extension)) {
+                this.extension, that.extension) || !Objects.equals(this.importedModuleNames, that.importedModuleNames)) {
             return false;
         }
         return Objects.equals(this.language, that.language);
@@ -196,6 +196,7 @@ public final class CodeCompilationUnit extends CodeModule {
         int result = super.hashCode();
         result = 31 * result + (this.pathElements != null ? this.pathElements.hashCode() : 0);
         result = 31 * result + (this.extension != null ? this.extension.hashCode() : 0);
-        return 31 * result + (this.language != null ? this.language.hashCode() : 0);
+        result = 31 * result + (this.language != null ? this.language.hashCode() : 0);
+        return 31 * result + (this.importedModuleNames != null ? this.importedModuleNames.hashCode() : 0);
     }
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
@@ -21,7 +21,7 @@ public final class ControlElement extends ComputationalObject {
 
     @JsonProperty
     private int startLine = -1;
-    
+
     @JsonProperty
     private int endLine = -1;
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
@@ -4,6 +4,7 @@ package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -58,7 +59,7 @@ public final class ControlElement extends ComputationalObject {
         super(codeItemRepository, name);
         this.startLine = startLine;
         this.endLine = endLine;
-        this.calleeNames = new ArrayList<>(calleeNames);
+        this.calleeNames = calleeNames != null ? new ArrayList<>(calleeNames) : new ArrayList<>();
     }
 
     /**
@@ -96,7 +97,7 @@ public final class ControlElement extends ComputationalObject {
         if (!(o instanceof ControlElement that) || !super.equals(o)) {
             return false;
         }
-        return this.startLine == that.startLine && this.endLine == that.endLine && (this.calleeNames != null ? this.calleeNames.equals(that.calleeNames) : that.calleeNames == null);
+        return this.startLine == that.startLine && this.endLine == that.endLine && Objects.equals(this.calleeNames, that.calleeNames);
     }
 
     @Override

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
@@ -1,8 +1,11 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 /**
@@ -14,6 +17,9 @@ public final class ControlElement extends ComputationalObject {
 
     @Serial
     private static final long serialVersionUID = -2733651783905632198L;
+
+    @JsonProperty
+    private List<String> calleeNames;
 
     /**
      * Default constructor for Jackson.
@@ -31,5 +37,26 @@ public final class ControlElement extends ComputationalObject {
      */
     public ControlElement(CodeItemRepository codeItemRepository, String name) {
         super(codeItemRepository, name);
+    }
+
+    /**
+     * Creates a new control element with the specified name and callee names.
+     *
+     * @param codeItemRepository the code item repository
+     * @param name               the name of the control element
+     * @param calleeNames        the names of the callees of this control element
+     */
+    public ControlElement(CodeItemRepository codeItemRepository, String name, List<String> calleeNames) {
+        super(codeItemRepository, name);
+        this.calleeNames = new ArrayList<>(calleeNames);
+    }
+
+    /**
+     * Returns the names of the callees of this control element.
+     *
+     * @return unmodifiable list of callee names
+     */
+    public List<String> getCalleeNames() {
+        return this.calleeNames != null ? List.copyOf(calleeNames) : List.of();
     }
 }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
@@ -1,6 +1,8 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.elements;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -14,6 +16,7 @@ public class Element {
     private int startLine;
     private int endLine;
     private String comment;
+    private List<String> imports = new ArrayList<>();
 
     public Element(String name, String path, Type type) {
         this(new ElementIdentifier(name, path, type));
@@ -59,7 +62,7 @@ public class Element {
         this.startLine = elementToCopy.getStartLine();
         this.endLine = elementToCopy.getEndLine();
         this.comment = elementToCopy.getComment();
-
+        this.imports = new ArrayList<>(elementToCopy.getImports());
     }
 
     public ElementIdentifier getParentIdentifier() {
@@ -104,6 +107,16 @@ public class Element {
         }
 
         this.comment += comment;
+    }
+
+    public void addImport(String importedName) {
+        if (!imports.contains(importedName)) {
+            imports.add(importedName);
+        }
+    }
+
+    public List<String> getImports() {
+        return List.copyOf(imports);
     }
 
     @Override

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
@@ -54,6 +54,7 @@ public class Element {
     }
 
     public Element(Element elementToCopy) {
+        Objects.requireNonNull(elementToCopy);
         this.identifier = new ElementIdentifier(elementToCopy.getIdentifier().name(), elementToCopy.getIdentifier().path(), elementToCopy.getIdentifier()
                 .type());
         if (elementToCopy.getParentIdentifier() != null) {

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
@@ -16,6 +16,7 @@ public class Element {
     private int startLine;
     private int endLine;
     private String comment;
+    private List<String> calleeNames = new ArrayList<>();
     private List<String> imports = new ArrayList<>();
 
     public Element(String name, String path, Type type) {
@@ -62,6 +63,7 @@ public class Element {
         this.startLine = elementToCopy.getStartLine();
         this.endLine = elementToCopy.getEndLine();
         this.comment = elementToCopy.getComment();
+        this.calleeNames = new ArrayList<>(elementToCopy.getCalleeNames());
         this.imports = new ArrayList<>(elementToCopy.getImports());
     }
 
@@ -117,6 +119,16 @@ public class Element {
 
     public List<String> getImports() {
         return List.copyOf(imports);
+    }
+
+    public void addCalleeName(String calleeName) {
+        if (!calleeNames.contains(calleeName)) {
+            calleeNames.add(calleeName);
+        }
+    }
+
+    public List<String> getCalleeNames() {
+        return List.copyOf(calleeNames);
     }
 
     @Override

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
@@ -291,7 +291,8 @@ public class JavaElementExtractor extends ElementExtractor {
                 .createdName()
                 .identifier()
                 .isEmpty()) {
-            names.add(oc.creator().createdName().identifier(0).getText());
+            List<JavaParser.IdentifierContext> ids = oc.creator().createdName().identifier();
+            names.add(ids.get(ids.size() - 1).getText());
         }
         for (int i = 0; i < tree.getChildCount(); i++) {
             collectCallNamesFromTree(tree.getChild(i), names);

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.extraction.java;
 
 import java.io.IOException;
@@ -10,6 +10,7 @@ import java.util.List;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
 
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.java.JavaLexer;
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.java.JavaParser;
@@ -55,8 +56,8 @@ public class JavaElementExtractor extends ElementExtractor {
     protected List<Path> getFiles(String directoryPath) {
         Path dir = Path.of(directoryPath);
         List<Path> javaFiles = new ArrayList<>();
-        try {
-            javaFiles.addAll(Files.walk(dir).filter(Files::isRegularFile).filter(f -> f.toString().endsWith(".java")).toList());
+        try (var files = Files.walk(dir)) {
+            javaFiles.addAll(files.filter(Files::isRegularFile).filter(f -> f.toString().endsWith(".java")).toList());
         } catch (IOException e) {
             logger.error("I/O operation failed", e);
         }
@@ -192,16 +193,17 @@ public class JavaElementExtractor extends ElementExtractor {
         int startLine = ctx.getStart().getLine();
         int endLine = ctx.getStop().getLine();
 
+        List<String> calleeNames = new ArrayList<>();
         if (ctx.methodBody() != null && ctx.methodBody().block() != null && ctx.methodBody().block().blockStatement() != null) {
             for (JavaParser.BlockStatementContext blockStatementContext : ctx.methodBody().block().blockStatement()) {
                 if (blockStatementContext.localVariableDeclaration() != null) {
                     visitLocalVariableDeclaration(blockStatementContext.localVariableDeclaration(), identifier);
                 }
             }
-
+            collectCallNamesFromTree(ctx.methodBody().block(), calleeNames);
         }
 
-        addFunction(name, path, parentIdentifier, startLine, endLine);
+        addFunction(name, path, parentIdentifier, startLine, endLine, calleeNames);
         return identifier;
     }
 
@@ -271,10 +273,29 @@ public class JavaElementExtractor extends ElementExtractor {
         elementRegistry.addClass(classElement);
     }
 
-    private void addFunction(String name, String path, ElementIdentifier parentIdentifier, int startLine, int endLine) {
+    private void addFunction(String name, String path, ElementIdentifier parentIdentifier, int startLine, int endLine, List<String> calleeNames) {
         Type type = Type.FUNCTION;
         Element method = new Element(name, path, type, parentIdentifier, startLine, endLine);
+        for (String callee : calleeNames) {
+            method.addCalleeName(callee);
+        }
         elementRegistry.addFunction(method);
+    }
+
+    private void collectCallNamesFromTree(ParseTree tree, List<String> names) {
+        if (tree instanceof JavaParser.MethodCallExpressionContext mc && mc.methodCall().identifier() != null) {
+            names.add(mc.methodCall().identifier().getText());
+        } else if (tree instanceof JavaParser.MemberReferenceExpressionContext mr && mr.methodCall() != null && mr.methodCall().identifier() != null) {
+            names.add(mr.methodCall().identifier().getText());
+        } else if (tree instanceof JavaParser.ObjectCreationExpressionContext oc && oc.creator() != null && oc.creator().createdName() != null && !oc.creator()
+                .createdName()
+                .identifier()
+                .isEmpty()) {
+            names.add(oc.creator().createdName().identifier(0).getText());
+        }
+        for (int i = 0; i < tree.getChildCount(); i++) {
+            collectCallNamesFromTree(tree.getChild(i), names);
+        }
     }
 
     private void addInterface(String name, String path, ElementIdentifier parentIdentifier, int startLine, int endLine) {

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
@@ -83,7 +83,17 @@ public class JavaElementExtractor extends ElementExtractor {
     }
 
     public void visitCompilationUnit(JavaParser.CompilationUnitContext ctx) {
-        ElementIdentifier identifier = addCompilationUnit(ctx);
+        List<String> imports = new ArrayList<>();
+        for (JavaParser.ImportDeclarationContext importCtx : ctx.importDeclaration()) {
+            if (importCtx.qualifiedName() != null) {
+                String name = importCtx.qualifiedName().getText();
+                if (importCtx.MUL() != null) {
+                    name = name + ".*";
+                }
+                imports.add(name);
+            }
+        }
+        ElementIdentifier identifier = addCompilationUnit(ctx, imports);
         for (JavaParser.TypeDeclarationContext typeDeclarationContext : ctx.typeDeclaration()) {
             if (typeDeclarationContext.classDeclaration() != null) {
                 visitClassDeclaration(typeDeclarationContext.classDeclaration(), identifier);
@@ -273,7 +283,7 @@ public class JavaElementExtractor extends ElementExtractor {
         elementRegistry.addInterface(interfaceElement);
     }
 
-    private ElementIdentifier addCompilationUnit(JavaParser.CompilationUnitContext ctx) {
+    private ElementIdentifier addCompilationUnit(JavaParser.CompilationUnitContext ctx, List<String> imports) {
         Type type = Type.COMPILATIONUNIT;
         Element compilationUnit = null;
         String path = PathExtractor.extractPath(ctx);
@@ -287,6 +297,9 @@ public class JavaElementExtractor extends ElementExtractor {
             compilationUnit = new Element(name, path, type, packageIdentifier);
         } else {
             compilationUnit = new Element(name, path, type);
+        }
+        for (String imp : imports) {
+            compilationUnit.addImport(imp);
         }
         elementRegistry.addCompilationUnit(compilationUnit);
         return identifier;

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.extraction.python3;
 
 import java.io.IOException;
@@ -11,6 +11,7 @@ import java.util.List;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
 
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.python3.Python3Lexer;
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.python3.Python3Parser;
@@ -153,12 +154,14 @@ public class Python3ElementExtractor extends ElementExtractor {
         int startLine = ctx.getStart().getLine();
         int endLine = ctx.getStop().getLine();
 
+        List<String> calleeNames = new ArrayList<>();
         if (ctx.block() != null && ctx.block().stmt() != null) {
             for (Python3Parser.StmtContext stmt : ctx.block().stmt()) {
                 visitStmt(stmt, identifier);
             }
+            collectCallNamesFromTree(ctx.block(), calleeNames);
         }
-        addFunctionElement(name, path, parentIdentifier, startLine, endLine);
+        addFunctionElement(name, path, parentIdentifier, startLine, endLine, calleeNames);
         return identifier;
     }
 
@@ -271,10 +274,47 @@ public class Python3ElementExtractor extends ElementExtractor {
         elementRegistry.addVariable(variable);
     }
 
-    private void addFunctionElement(String name, String path, ElementIdentifier parentIdentifier, int startLine, int endLine) {
+    private void addFunctionElement(String name, String path, ElementIdentifier parentIdentifier, int startLine, int endLine, List<String> calleeNames) {
         Type type = Type.FUNCTION;
         Element function = new Element(name, path, type, parentIdentifier, startLine, endLine);
+        for (String callee : calleeNames) {
+            function.addCalleeName(callee);
+        }
         elementRegistry.addFunction(function);
+    }
+
+    private void collectCallNamesFromTree(ParseTree tree, List<String> names) {
+        if (tree instanceof Python3Parser.Atom_exprContext atomExpr) {
+            collectCallNamesFromAtomExpr(atomExpr, names);
+        }
+        for (int i = 0; i < tree.getChildCount(); i++) {
+            collectCallNamesFromTree(tree.getChild(i), names);
+        }
+    }
+
+    private void collectCallNamesFromAtomExpr(Python3Parser.Atom_exprContext atomExpr, List<String> names) {
+        if (atomExpr.trailer() == null || atomExpr.trailer().isEmpty()) {
+            return;
+        }
+        List<Python3Parser.TrailerContext> trailers = atomExpr.trailer();
+        for (int i = 0; i < trailers.size(); i++) {
+            Python3Parser.TrailerContext trailer = trailers.get(i);
+            if (trailer.getChildCount() > 0 && "(".equals(trailer.getChild(0).getText())) {
+                if (i > 0) {
+                    // obj.method() — the preceding trailer is ".method"
+                    Python3Parser.TrailerContext prev = trailers.get(i - 1);
+                    if (prev.name() != null) {
+                        names.add(prev.name().getText());
+                    }
+                } else {
+                    // bare call: helper() — atom is the function name
+                    Python3Parser.AtomContext atom = atomExpr.atom();
+                    if (atom != null && atom.name() != null) {
+                        names.add(atom.name().getText());
+                    }
+                }
+            }
+        }
     }
 
     private void addClassElement(String name, String path, ElementIdentifier parentIdentifier, List<String> childClassOf, int startLine, int endLine) {

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
@@ -173,22 +173,29 @@ public class Python3ElementExtractor extends ElementExtractor {
         }
     }
 
+    private void visitImport_name(Python3Parser.Import_nameContext ctx, List<String> importedNames) {
+        for (Python3Parser.Dotted_as_nameContext dotted : ctx.dotted_as_names().dotted_as_name()) {
+            importedNames.add(dotted.dotted_name().getText());
+        }
+    }
+
+    private void visitImport_from(Python3Parser.Import_fromContext ctx, List<String> importedNames) {
+        String base = ctx.dotted_name() != null ? ctx.dotted_name().getText() : "";
+        if (ctx.import_as_names() != null) {
+            for (Python3Parser.Import_as_nameContext name : ctx.import_as_names().import_as_name()) {
+                importedNames.add(base.isEmpty() ? name.name(0).getText() : base + "." + name.name(0).getText());
+            }
+        } else if (!base.isEmpty()) {
+            importedNames.add(base);
+        }
+    }
+
     public void visitImport_stmt(Python3Parser.Import_stmtContext ctx) {
         List<String> importedNames = new ArrayList<>();
         if (ctx.import_name() != null) {
-            for (Python3Parser.Dotted_as_nameContext dotted : ctx.import_name().dotted_as_names().dotted_as_name()) {
-                importedNames.add(dotted.dotted_name().getText());
-            }
+            visitImport_name(ctx.import_name(), importedNames);
         } else if (ctx.import_from() != null) {
-            Python3Parser.Import_fromContext from = ctx.import_from();
-            String base = from.dotted_name() != null ? from.dotted_name().getText() : "";
-            if (from.import_as_names() != null) {
-                for (Python3Parser.Import_as_nameContext name : from.import_as_names().import_as_name()) {
-                    importedNames.add(base.isEmpty() ? name.name(0).getText() : base + "." + name.name(0).getText());
-                }
-            } else if (!base.isEmpty()) {
-                importedNames.add(base);
-            }
+            visitImport_from(ctx.import_from(), importedNames);
         }
         String importPath = PathExtractor.extractPath(ctx);
         if (!pendingImportsByPath.containsKey(importPath)) {
@@ -285,14 +292,26 @@ public class Python3ElementExtractor extends ElementExtractor {
 
     private void collectCallNamesFromTree(ParseTree tree, List<String> names) {
         if (tree instanceof Python3Parser.Atom_exprContext atomExpr) {
-            collectCallNamesFromAtomExpr(atomExpr, names);
+            visitAtom_expr(atomExpr, names);
         }
         for (int i = 0; i < tree.getChildCount(); i++) {
             collectCallNamesFromTree(tree.getChild(i), names);
         }
     }
 
-    private void collectCallNamesFromAtomExpr(Python3Parser.Atom_exprContext atomExpr, List<String> names) {
+    private void collectCallNameFromTrailer(Python3Parser.TrailerContext trailer, List<String> names) {
+        if (trailer.name() != null) {
+            names.add(trailer.name().getText());
+        }
+    }
+
+    private void collectCallNameFromAtom(Python3Parser.AtomContext atom, List<String> names) {
+        if (atom.name() != null) {
+            names.add(atom.name().getText());
+        }
+    }
+
+    private void visitAtom_expr(Python3Parser.Atom_exprContext atomExpr, List<String> names) {
         if (atomExpr.trailer() == null || atomExpr.trailer().isEmpty()) {
             return;
         }
@@ -301,17 +320,9 @@ public class Python3ElementExtractor extends ElementExtractor {
             Python3Parser.TrailerContext trailer = trailers.get(i);
             if (trailer.getChildCount() > 0 && "(".equals(trailer.getChild(0).getText())) {
                 if (i > 0) {
-                    // obj.method() — the preceding trailer is ".method"
-                    Python3Parser.TrailerContext prev = trailers.get(i - 1);
-                    if (prev.name() != null) {
-                        names.add(prev.name().getText());
-                    }
+                    collectCallNameFromTrailer(trailers.get(i - 1), names);
                 } else {
-                    // bare call: helper() — atom is the function name
-                    Python3Parser.AtomContext atom = atomExpr.atom();
-                    if (atom != null && atom.name() != null) {
-                        names.add(atom.name().getText());
-                    }
+                    collectCallNameFromAtom(atomExpr.atom(), names);
                 }
             }
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.antlr.v4.runtime.CharStream;
@@ -34,6 +35,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.managem
 @SuppressWarnings("java:S100")
 public class Python3ElementExtractor extends ElementExtractor {
     private final Python3ElementStorageRegistry elementRegistry;
+    private final LinkedHashMap<String, List<String>> pendingImportsByPath = new LinkedHashMap<>();
 
     public Python3ElementExtractor() {
         super();
@@ -163,7 +165,33 @@ public class Python3ElementExtractor extends ElementExtractor {
     public void visitSimple_stmt(Python3Parser.Simple_stmtContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.expr_stmt() != null) {
             visitExpr_stmt(ctx.expr_stmt(), parentIdentifier);
+        } else if (ctx.import_stmt() != null) {
+            visitImport_stmt(ctx.import_stmt());
         }
+    }
+
+    public void visitImport_stmt(Python3Parser.Import_stmtContext ctx) {
+        List<String> importedNames = new ArrayList<>();
+        if (ctx.import_name() != null) {
+            for (Python3Parser.Dotted_as_nameContext dotted : ctx.import_name().dotted_as_names().dotted_as_name()) {
+                importedNames.add(dotted.dotted_name().getText());
+            }
+        } else if (ctx.import_from() != null) {
+            Python3Parser.Import_fromContext from = ctx.import_from();
+            String base = from.dotted_name() != null ? from.dotted_name().getText() : "";
+            if (from.import_as_names() != null) {
+                for (Python3Parser.Import_as_nameContext name : from.import_as_names().import_as_name()) {
+                    importedNames.add(base.isEmpty() ? name.name(0).getText() : base + "." + name.name(0).getText());
+                }
+            } else if (!base.isEmpty()) {
+                importedNames.add(base);
+            }
+        }
+        String importPath = PathExtractor.extractPath(ctx);
+        if (!pendingImportsByPath.containsKey(importPath)) {
+            pendingImportsByPath.put(importPath, new ArrayList<>());
+        }
+        pendingImportsByPath.get(importPath).addAll(importedNames);
     }
 
     public void visitExpr_stmt(Python3Parser.Expr_stmtContext ctx, ElementIdentifier parentIdentifier) {
@@ -262,6 +290,10 @@ public class Python3ElementExtractor extends ElementExtractor {
         String packageName = addPackage(packagePath);
         ElementIdentifier parentIdentifier = new ElementIdentifier(packageName, packagePath, Type.PACKAGE);
         Element module = new Element(name, path, type, parentIdentifier);
+        List<String> imports = pendingImportsByPath.containsKey(path) ? pendingImportsByPath.get(path) : List.of();
+        for (String imp : imports) {
+            module.addImport(imp);
+        }
         elementRegistry.addModule(module);
     }
 

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FileMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FileMapper.java
@@ -1,6 +1,8 @@
 /* Licensed under MIT 2025. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.cpp.mappers;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.SortedSet;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeAssembly;
@@ -35,6 +37,10 @@ public class FileMapper extends AbstractCppCodeItemMapper {
     private CodeItem buildFileCodeAssembly(ElementIdentifier identifier) {
         Element file = this.elementRegistry.getFile(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
-        return new CodeAssembly(this.codeItemRepository, file.getName(), content, this.language.name());
+        String path = file.getPath();
+        int lastSlash = path.lastIndexOf('/');
+        List<String> pathElements = lastSlash >= 0 ? Arrays.asList(path.substring(0, lastSlash).split("/")) : List.of();
+        String extension = path.substring(path.lastIndexOf('.') + 1);
+        return new CodeAssembly(this.codeItemRepository, file.getName(), content, this.language.name(), pathElements, extension, file.getImports());
     }
 }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FileMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FileMapper.java
@@ -1,8 +1,6 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.cpp.mappers;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.SortedSet;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeAssembly;
@@ -37,10 +35,6 @@ public class FileMapper extends AbstractCppCodeItemMapper {
     private CodeItem buildFileCodeAssembly(ElementIdentifier identifier) {
         Element file = this.elementRegistry.getFile(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
-        String path = file.getPath();
-        int lastSlash = path.lastIndexOf('/');
-        List<String> pathElements = lastSlash >= 0 ? Arrays.asList(path.substring(0, lastSlash).split("/")) : List.of();
-        String extension = path.substring(path.lastIndexOf('.') + 1);
-        return new CodeAssembly(this.codeItemRepository, file.getName(), content, this.language.name(), pathElements, extension, file.getImports());
+        return new CodeAssembly(this.codeItemRepository, file.getName(), content, this.language.name(), file.getImports());
     }
 }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FunctionMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.cpp.mappers;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
@@ -33,7 +33,7 @@ public class FunctionMapper extends AbstractCppCodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getCalleeNames());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/cpp/mappers/FunctionMapper.java
@@ -32,8 +32,9 @@ public class FunctionMapper extends AbstractCppCodeItemMapper {
 
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
-        
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine(), function.getCalleeNames());
+
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine(), function
+                .getCalleeNames());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/CompilationUnitMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/CompilationUnitMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.java.mappers;
 
 import java.util.Arrays;
@@ -43,7 +43,7 @@ public class CompilationUnitMapper extends AbstractJavaCodeItemMapper {
 
         PackageElement pack = elementRegistry.getPackage(compilationUnit.getParentIdentifier());
         CodeCompilationUnit codeCompilationUnit = new CodeCompilationUnit(codeItemRepository, compilationUnit.getName(), content, pathElements, pack.getName(),
-                this.language);
+                this.language, compilationUnit.getImports());
         codeCompilationUnit.setComment(compilationUnit.getComment());
         return codeCompilationUnit;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/FunctionMapper.java
@@ -33,7 +33,8 @@ public class FunctionMapper extends AbstractJavaCodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine(), function.getCalleeNames());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine(), function
+                .getCalleeNames());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/java/mappers/FunctionMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.java.mappers;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
@@ -33,7 +33,7 @@ public class FunctionMapper extends AbstractJavaCodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getCalleeNames());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/FunctionMapper.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.python3.mappers;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
@@ -34,7 +34,7 @@ public class FunctionMapper extends AbstractPython3CodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getCalleeNames());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/FunctionMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/FunctionMapper.java
@@ -34,7 +34,8 @@ public class FunctionMapper extends AbstractPython3CodeItemMapper {
     private CodeItem buildControlElement(ElementIdentifier identifier) {
         Element function = this.elementRegistry.getFunction(identifier);
 
-        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine(), function.getCalleeNames());
+        ControlElement controlElement = new ControlElement(codeItemRepository, function.getName(), function.getStartLine(), function.getEndLine(), function
+                .getCalleeNames());
         controlElement.setComment(function.getComment());
         return controlElement;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/ModuleMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/ModuleMapper.java
@@ -1,8 +1,6 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.python3.mappers;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.SortedSet;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeAssembly;
@@ -37,12 +35,7 @@ public class ModuleMapper extends AbstractPython3CodeItemMapper {
     private CodeAssembly buildCodeAssembly(ElementIdentifier identifier) {
         Element module = elementRegistry.getModule(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
-        String path = module.getPath();
-        int lastSlash = path.lastIndexOf('/');
-        List<String> pathElements = lastSlash >= 0 ? Arrays.asList(path.substring(0, lastSlash).split("/")) : List.of();
-        String extension = path.substring(path.lastIndexOf('.') + 1);
-        CodeAssembly codeAssembly = new CodeAssembly(codeItemRepository, module.getName(), content, this.language.name(), pathElements, extension, module
-                .getImports());
+        CodeAssembly codeAssembly = new CodeAssembly(codeItemRepository, module.getName(), content, this.language.name(), module.getImports());
         codeAssembly.setComment(module.getComment());
         return codeAssembly;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/ModuleMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/python3/mappers/ModuleMapper.java
@@ -1,6 +1,8 @@
 /* Licensed under MIT 2025. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping.python3.mappers;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.SortedSet;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeAssembly;
@@ -35,7 +37,12 @@ public class ModuleMapper extends AbstractPython3CodeItemMapper {
     private CodeAssembly buildCodeAssembly(ElementIdentifier identifier) {
         Element module = elementRegistry.getModule(identifier);
         SortedSet<CodeItem> content = buildContent(identifier);
-        CodeAssembly codeAssembly = new CodeAssembly(codeItemRepository, module.getName(), content, this.language.name());
+        String path = module.getPath();
+        int lastSlash = path.lastIndexOf('/');
+        List<String> pathElements = lastSlash >= 0 ? Arrays.asList(path.substring(0, lastSlash).split("/")) : List.of();
+        String extension = path.substring(path.lastIndexOf('.') + 1);
+        CodeAssembly codeAssembly = new CodeAssembly(codeItemRepository, module.getName(), content, this.language.name(), pathElements, extension, module
+                .getImports());
         codeAssembly.setComment(module.getComment());
         return codeAssembly;
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
@@ -150,6 +150,19 @@ public final class JavaModel {
         }
     }
 
+    /**
+     * Returns the fully-qualified names of all imports declared in the given AST
+     * compilation unit.
+     */
+    private static List<String> extractImportedModuleNames(CompilationUnit astUnit) {
+        @SuppressWarnings("unchecked") List<ImportDeclaration> imports = astUnit.imports();
+        List<String> importedNames = new ArrayList<>();
+        for (ImportDeclaration importDeclaration : imports) {
+            importedNames.add(importDeclaration.getName().getFullyQualifiedName());
+        }
+        return importedNames;
+    }
+
     private static List<ITypeBinding> getReferencedBindings(AbstractTypeDeclaration abstractTypeDeclaration) {
         @SuppressWarnings("unchecked") List<BodyDeclaration> bodyDeclarations = abstractTypeDeclaration.bodyDeclarations();
         List<Type> referencedTypes = new ArrayList<>();
@@ -190,8 +203,9 @@ public final class JavaModel {
                 Name fullName = packageDeclaration.getName();
                 packageNames = getPackageNames(fullName);
             }
+            List<String> importedModuleNames = extractImportedModuleNames(compilationUnit);
             CodeCompilationUnit codeCompilationUnit = new CodeCompilationUnit(codeItemRepository, fileNameWithoutExtension, new TreeSet<>(), pathElements,
-                    extension, ProgrammingLanguage.JAVA);
+                    extension, ProgrammingLanguage.JAVA, importedModuleNames);
             codeCompilationUnits.add(codeCompilationUnit);
             if (null != packageDeclaration) {
                 CodePackage codePackage = getPackage(packageNames, codeCompilationUnit);

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
@@ -235,11 +235,11 @@ public final class JavaModel {
         Map<ASTNode, Datatype> codeTypes = new LinkedHashMap<>();
         Set<TypeDeclaration> typeDeclarations = TypeDeclarationFinder.find(compilationUnit);
         for (TypeDeclaration typeDeclaration : typeDeclarations) {
-            codeTypes.put(typeDeclaration, processTypeDeclaration(typeDeclaration, compilationUnit));
+            codeTypes.put(typeDeclaration, processTypeDeclaration(typeDeclaration));
         }
         Set<EnumDeclaration> enumDeclarations = EnumDeclarationFinder.find(compilationUnit);
         for (EnumDeclaration enumDeclaration : enumDeclarations) {
-            codeTypes.put(enumDeclaration, processEnumDeclaration(enumDeclaration, compilationUnit));
+            codeTypes.put(enumDeclaration, processEnumDeclaration(enumDeclaration));
         }
         for (var entry : codeTypes.entrySet()) {
             ASTNode node = entry.getKey();
@@ -251,17 +251,17 @@ public final class JavaModel {
         return codeTypes.values().stream().toList();
     }
 
-    private ClassUnit processEnumDeclaration(EnumDeclaration enumDeclaration, CompilationUnit compilationUnit) {
+    private ClassUnit processEnumDeclaration(EnumDeclaration enumDeclaration) {
         String name = enumDeclaration.getName().getIdentifier();
-        SortedSet<ControlElement> declaredMethods = extractMethods(enumDeclaration, compilationUnit);
+        SortedSet<ControlElement> declaredMethods = extractMethods(enumDeclaration);
         ClassUnit codeClassifier = new ClassUnit(codeItemRepository, name, declaredMethods);
         addClassifier(codeClassifier, enumDeclaration);
         return codeClassifier;
     }
 
-    private Datatype processTypeDeclaration(TypeDeclaration typeDeclaration, CompilationUnit compilationUnit) {
+    private Datatype processTypeDeclaration(TypeDeclaration typeDeclaration) {
         String name = typeDeclaration.getName().getIdentifier();
-        SortedSet<ControlElement> declaredMethods = extractMethods(typeDeclaration, compilationUnit);
+        SortedSet<ControlElement> declaredMethods = extractMethods(typeDeclaration);
         Datatype codeType;
         if (typeDeclaration.isInterface()) {
             InterfaceUnit codeInterface = new InterfaceUnit(codeItemRepository, name, declaredMethods);
@@ -275,16 +275,16 @@ public final class JavaModel {
         return codeType;
     }
 
-    private SortedSet<ControlElement> extractMethods(ASTNode node, CompilationUnit compilationUnit) {
+    private SortedSet<ControlElement> extractMethods(ASTNode node) {
         SortedSet<ControlElement> declaredMethods = new TreeSet<>();
         Set<MethodDeclaration> methodDeclarations = MethodDeclarationFinder.find(node);
         for (MethodDeclaration methodDeclaration : methodDeclarations) {
-            declaredMethods.add(extractMethod(methodDeclaration, compilationUnit));
+            declaredMethods.add(extractMethod(methodDeclaration));
         }
         return declaredMethods;
     }
 
-    private ControlElement extractMethod(MethodDeclaration methodDeclaration, CompilationUnit compilationUnit) {
+    private ControlElement extractMethod(MethodDeclaration methodDeclaration) {
         List<String> calleeNames = new ArrayList<>();
         methodDeclaration.accept(new ASTVisitor() {
             @Override
@@ -299,8 +299,7 @@ public final class JavaModel {
                 return true;
             }
         });
-        ControlElement controlElement = new ControlElement(codeItemRepository, methodDeclaration.getName().getIdentifier(), calleeNames);
-        return controlElement;
+        return new ControlElement(codeItemRepository, methodDeclaration.getName().getIdentifier(), calleeNames);
     }
 
     private static List<String> getPackageNames(Name name) {

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.java;
 
 import java.nio.file.Path;
@@ -235,11 +235,11 @@ public final class JavaModel {
         Map<ASTNode, Datatype> codeTypes = new LinkedHashMap<>();
         Set<TypeDeclaration> typeDeclarations = TypeDeclarationFinder.find(compilationUnit);
         for (TypeDeclaration typeDeclaration : typeDeclarations) {
-            codeTypes.put(typeDeclaration, processTypeDeclaration(typeDeclaration));
+            codeTypes.put(typeDeclaration, processTypeDeclaration(typeDeclaration, compilationUnit));
         }
         Set<EnumDeclaration> enumDeclarations = EnumDeclarationFinder.find(compilationUnit);
         for (EnumDeclaration enumDeclaration : enumDeclarations) {
-            codeTypes.put(enumDeclaration, processEnumDeclaration(enumDeclaration));
+            codeTypes.put(enumDeclaration, processEnumDeclaration(enumDeclaration, compilationUnit));
         }
         for (var entry : codeTypes.entrySet()) {
             ASTNode node = entry.getKey();
@@ -251,17 +251,17 @@ public final class JavaModel {
         return codeTypes.values().stream().toList();
     }
 
-    private ClassUnit processEnumDeclaration(EnumDeclaration enumDeclaration) {
+    private ClassUnit processEnumDeclaration(EnumDeclaration enumDeclaration, CompilationUnit compilationUnit) {
         String name = enumDeclaration.getName().getIdentifier();
-        SortedSet<ControlElement> declaredMethods = extractMethods(enumDeclaration);
+        SortedSet<ControlElement> declaredMethods = extractMethods(enumDeclaration, compilationUnit);
         ClassUnit codeClassifier = new ClassUnit(codeItemRepository, name, declaredMethods);
         addClassifier(codeClassifier, enumDeclaration);
         return codeClassifier;
     }
 
-    private Datatype processTypeDeclaration(TypeDeclaration typeDeclaration) {
+    private Datatype processTypeDeclaration(TypeDeclaration typeDeclaration, CompilationUnit compilationUnit) {
         String name = typeDeclaration.getName().getIdentifier();
-        SortedSet<ControlElement> declaredMethods = extractMethods(typeDeclaration);
+        SortedSet<ControlElement> declaredMethods = extractMethods(typeDeclaration, compilationUnit);
         Datatype codeType;
         if (typeDeclaration.isInterface()) {
             InterfaceUnit codeInterface = new InterfaceUnit(codeItemRepository, name, declaredMethods);
@@ -275,17 +275,32 @@ public final class JavaModel {
         return codeType;
     }
 
-    private SortedSet<ControlElement> extractMethods(ASTNode node) {
+    private SortedSet<ControlElement> extractMethods(ASTNode node, CompilationUnit compilationUnit) {
         SortedSet<ControlElement> declaredMethods = new TreeSet<>();
         Set<MethodDeclaration> methodDeclarations = MethodDeclarationFinder.find(node);
         for (MethodDeclaration methodDeclaration : methodDeclarations) {
-            declaredMethods.add(extractMethod(methodDeclaration));
+            declaredMethods.add(extractMethod(methodDeclaration, compilationUnit));
         }
         return declaredMethods;
     }
 
-    private ControlElement extractMethod(MethodDeclaration methodDeclaration) {
-        return new ControlElement(codeItemRepository, methodDeclaration.getName().getIdentifier());
+    private ControlElement extractMethod(MethodDeclaration methodDeclaration, CompilationUnit compilationUnit) {
+        List<String> calleeNames = new ArrayList<>();
+        methodDeclaration.accept(new ASTVisitor() {
+            @Override
+            public boolean visit(MethodInvocation node) {
+                calleeNames.add(node.getName().getIdentifier());
+                return true;
+            }
+
+            @Override
+            public boolean visit(ClassInstanceCreation node) {
+                calleeNames.add(node.getType().toString());
+                return true;
+            }
+        });
+        ControlElement controlElement = new ControlElement(codeItemRepository, methodDeclaration.getName().getIdentifier(), calleeNames);
+        return controlElement;
     }
 
     private static List<String> getPackageNames(Name name) {

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/shell/ShellVisitor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/shell/ShellVisitor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.shell;
 
 import java.io.FileReader;
@@ -91,7 +91,8 @@ public class ShellVisitor implements FileVisitor<Path> {
         for (int i = 0; i < relativePath.getNameCount() - 1; i++) {
             pathElements.add(relativePath.getName(i).toString());
         }
-        return new CodeCompilationUnit(codeItemRepository, fileNameWithoutExtension, new TreeSet<>(), pathElements, extension, ProgrammingLanguage.SHELL);
+        return new CodeCompilationUnit(codeItemRepository, fileNameWithoutExtension, new TreeSet<>(), pathElements, extension, ProgrammingLanguage.SHELL, List
+                .of());
     }
 
     private boolean isShellFile(String code) {

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/java/JavaControlExtractorTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/java/JavaControlExtractorTest.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.antlr.extraction.java;
 
 import java.io.IOException;
@@ -66,6 +66,21 @@ class JavaControlExtractorTest {
         String filePath = sourcePath + "drei/OtherInterface.java";
         List<Element> controls = extractBasicElementsFromFile(filePath);
         Assertions.assertTrue(controls.isEmpty());
+    }
+
+    @Test
+    void controlExtractorCalleeNamesTest() throws IOException {
+        String filePath = sourcePath + "AClassWithCalls.java";
+        List<Element> controls = extractBasicElementsFromFile(filePath);
+        Assertions.assertEquals(3, controls.size());
+
+        Element caller = controls.stream().filter(e -> "caller".equals(e.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(caller.getCalleeNames().contains("helper"));
+        Assertions.assertTrue(caller.getCalleeNames().contains("TestClass"));
+        Assertions.assertTrue(caller.getCalleeNames().contains("method"));
+
+        Element helper = controls.stream().filter(e -> "helper".equals(e.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(helper.getCalleeNames().isEmpty());
     }
 
     private List<Element> extractBasicElementsFromFile(String filePath) throws IOException {

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/java/JavaExtractorTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/java/JavaExtractorTest.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.antlr.extraction.java;
 
 import org.junit.jupiter.api.Assertions;
@@ -18,11 +18,11 @@ class JavaExtractorTest {
         JavaElementStorageRegistry manager = (JavaElementStorageRegistry) javaExtractor.getElementExtractor().getElements();
 
         // Assertions
-        Assertions.assertEquals(3, manager.getVariables().size());
-        Assertions.assertEquals(1, manager.getFunctions().size());
-        Assertions.assertEquals(6, manager.getClasses().size());
+        Assertions.assertEquals(4, manager.getVariables().size());
+        Assertions.assertEquals(4, manager.getFunctions().size());
+        Assertions.assertEquals(8, manager.getClasses().size());
         Assertions.assertEquals(4, manager.getInterfaces().size());
-        Assertions.assertEquals(7, manager.getCompilationUnits().size());
+        Assertions.assertEquals(8, manager.getCompilationUnits().size());
         Assertions.assertEquals(3, manager.getPackages().size());
     }
 

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/python3/Python3ControlExtractorTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/python3/Python3ControlExtractorTest.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.antlr.extraction.python3;
 
 import java.io.IOException;
@@ -99,6 +99,21 @@ class Python3ControlExtractorTest {
         String filePath = sourcePath + "APyEnum.py";
         List<Element> controls = extractBasicElementsFromFile(filePath);
         Assertions.assertEquals(0, controls.size());
+    }
+
+    @Test
+    void testCalleeNamesExtracted() throws IOException {
+        String filePath = sourcePath + "APyModuleWithCalls.py";
+        List<Element> controls = extractBasicElementsFromFile(filePath);
+        Assertions.assertEquals(3, controls.size());
+
+        Element caller = controls.stream().filter(e -> "caller".equals(e.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(caller.getCalleeNames().contains("helper"));
+        Assertions.assertTrue(caller.getCalleeNames().contains("TestClass"));
+        Assertions.assertTrue(caller.getCalleeNames().contains("method"));
+
+        Element helper = controls.stream().filter(e -> "helper".equals(e.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(helper.getCalleeNames().isEmpty());
     }
 
     private List<Element> extractBasicElementsFromFile(String filePath) throws IOException {

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/python3/Python3ExtractorTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/extraction/python3/Python3ExtractorTest.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.antlr.extraction.python3;
 
 import org.junit.jupiter.api.Assertions;
@@ -18,10 +18,10 @@ class Python3ExtractorTest {
         Python3ElementStorageRegistry manager = (Python3ElementStorageRegistry) python3Extractor.getElementExtractor().getElements();
 
         // Assertions
-        Assertions.assertEquals(13, manager.getVariables().size());
-        Assertions.assertEquals(17, manager.getFunctions().size());
-        Assertions.assertEquals(10, manager.getClasses().size());
-        Assertions.assertEquals(8, manager.getModules().size());
+        Assertions.assertEquals(14, manager.getVariables().size());
+        Assertions.assertEquals(20, manager.getFunctions().size());
+        Assertions.assertEquals(11, manager.getClasses().size());
+        Assertions.assertEquals(9, manager.getModules().size());
     }
 
     private Python3Extractor buildPython3Extractor(String sourcePath) {

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/mappers/JavaModelMapperTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/mappers/JavaModelMapperTest.java
@@ -21,7 +21,7 @@ class JavaModelMapperTest {
 
         // Assertions
         Assertions.assertNotNull(codeModel);
-        Assertions.assertEquals(7, codeModel.getEndpoints().size());
+        Assertions.assertEquals(8, codeModel.getEndpoints().size());
 
         // More Detailed Assertions
         Assertions.assertEquals(3, codeModel.getAllPackages().size());

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/mappers/JavaModelMapperTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/mappers/JavaModelMapperTest.java
@@ -1,10 +1,13 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.antlr.mappers;
+
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
+import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeCompilationUnit;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.extraction.java.JavaExtractor;
 
@@ -23,6 +26,9 @@ class JavaModelMapperTest {
         // More Detailed Assertions
         Assertions.assertEquals(3, codeModel.getAllPackages().size());
 
+        Stream<CodeCompilationUnit> allCompilationUnits = codeModel.getAllPackages().stream().flatMap(p -> p.getCompilationUnits().stream());
+        CodeCompilationUnit aClass = allCompilationUnits.filter(cu -> "AClass".equals(cu.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(aClass.getImportedModuleNames().contains("edu.zwei.OtherInterface"));
     }
 
 }

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/mappers/Python3ModelMapperTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/antlr/mappers/Python3ModelMapperTest.java
@@ -1,10 +1,13 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.antlr.mappers;
+
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
+import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeAssembly;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.extraction.python3.Python3Extractor;
 
@@ -19,6 +22,24 @@ class Python3ModelMapperTest {
         // More Detailed Assertions
         Assertions.assertEquals(3, codeModel.getAllPackages().size());
 
+    }
+
+    @Test
+    void importsArePopulatedOnAssemblies() {
+        CodeItemRepository repository = new CodeItemRepository();
+        Python3Extractor extractor = new Python3Extractor(repository, "src/test/resources/python/interface/edu/");
+        CodeModel codeModel = extractor.extractModel();
+
+        CodeAssembly abcAssembly = allAssemblies(codeModel).filter(a -> "APyAbstractBaseClass".equals(a.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(abcAssembly.getImportedModuleNames().contains("abc.ABC"));
+        Assertions.assertTrue(abcAssembly.getImportedModuleNames().contains("abc.abstractmethod"));
+
+        CodeAssembly dataclassAssembly = allAssemblies(codeModel).filter(a -> "APyDataClass".equals(a.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(dataclassAssembly.getImportedModuleNames().contains("dataclasses.dataclass"));
+    }
+
+    private static Stream<CodeAssembly> allAssemblies(CodeModel codeModel) {
+        return codeModel.getAllPackages().stream().flatMap(p -> p.getContent().stream()).filter(CodeAssembly.class::isInstance).map(CodeAssembly.class::cast);
     }
 
 }

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/java/JavaExtractorTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/java/JavaExtractorTest.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.java;
+
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import edu.kit.kastel.mcse.ardoco.core.api.entity.Entity;
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
+import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeCompilationUnit;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.java.JavaExtractor;
 
@@ -26,5 +29,9 @@ class JavaExtractorTest {
         }
 
         Assertions.assertEquals(7, model.getEndpoints().size());
+
+        Stream<CodeCompilationUnit> allCompilationUnits = model.getAllPackages().stream().flatMap(p -> p.getCompilationUnits().stream());
+        CodeCompilationUnit aClass = allCompilationUnits.filter(u -> "AClass".equals(u.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(aClass.getImportedModuleNames().contains("edu.zwei.OtherInterface"));
     }
 }

--- a/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/java/JavaExtractorTest.java
+++ b/tlr/stages-tlr/model-provider/src/test/java/edu/kit/kastel/mcse/ardoco/tlr/models/generators/java/JavaExtractorTest.java
@@ -1,7 +1,9 @@
 /* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.generators.java;
 
-import java.util.stream.Stream;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,7 @@ import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeCompilationUnit;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
+import edu.kit.kastel.mcse.ardoco.core.api.models.code.ControlElement;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.java.JavaExtractor;
 
 class JavaExtractorTest {
@@ -28,10 +31,24 @@ class JavaExtractorTest {
             logger.info("Package: {}", codePackage);
         }
 
-        Assertions.assertEquals(7, model.getEndpoints().size());
+        Assertions.assertEquals(8, model.getEndpoints().size());
 
-        Stream<CodeCompilationUnit> allCompilationUnits = model.getAllPackages().stream().flatMap(p -> p.getCompilationUnits().stream());
-        CodeCompilationUnit aClass = allCompilationUnits.filter(u -> "AClass".equals(u.getName())).findFirst().orElseThrow();
+        List<CodeCompilationUnit> allCompilationUnits = model.getAllPackages().stream().flatMap(p -> p.getCompilationUnits().stream()).toList();
+        CodeCompilationUnit aClass = allCompilationUnits.stream().filter(u -> "AClass".equals(u.getName())).findFirst().orElseThrow();
         Assertions.assertTrue(aClass.getImportedModuleNames().contains("edu.zwei.OtherInterface"));
+
+        CodeCompilationUnit callsUnit = allCompilationUnits.stream().filter(u -> "AClassWithCalls".equals(u.getName())).findFirst().orElseThrow();
+        SortedSet<ControlElement> allMethods = new TreeSet<>();
+        for (var dt : callsUnit.getAllDataTypes()) {
+            allMethods.addAll(dt.getDeclaredMethods());
+        }
+
+        ControlElement caller = allMethods.stream().filter(m -> "caller".equals(m.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(caller.getCalleeNames().contains("helper"));
+        Assertions.assertTrue(caller.getCalleeNames().contains("TestClass"));
+        Assertions.assertTrue(caller.getCalleeNames().contains("method"));
+
+        ControlElement helper = allMethods.stream().filter(m -> "helper".equals(m.getName())).findFirst().orElseThrow();
+        Assertions.assertTrue(helper.getCalleeNames().isEmpty());
     }
 }

--- a/tlr/stages-tlr/model-provider/src/test/resources/interface/edu/AClassWithCalls.java
+++ b/tlr/stages-tlr/model-provider/src/test/resources/interface/edu/AClassWithCalls.java
@@ -1,0 +1,18 @@
+package edu;
+
+public class TestClass {
+    public void method() {
+    }
+}
+
+
+public class AClassWithCalls {
+    public void caller() {
+        helper();
+        TestClass other = new TestClass();
+        other.method();
+    }
+
+    private void helper() {
+    }
+}

--- a/tlr/stages-tlr/model-provider/src/test/resources/interface/edu/AClassWithCalls.java
+++ b/tlr/stages-tlr/model-provider/src/test/resources/interface/edu/AClassWithCalls.java
@@ -2,6 +2,7 @@ package edu;
 
 public class TestClass {
     public void method() {
+        /* empty for test purposes */
     }
 }
 
@@ -14,5 +15,6 @@ public class AClassWithCalls {
     }
 
     private void helper() {
+        /* empty for test purposes */
     }
 }

--- a/tlr/stages-tlr/model-provider/src/test/resources/python/interface/edu/APyModuleWithCalls.py
+++ b/tlr/stages-tlr/model-provider/src/test/resources/python/interface/edu/APyModuleWithCalls.py
@@ -1,0 +1,12 @@
+class TestClass:
+    def method(self):
+        pass
+
+def caller():
+    helper()
+    obj = TestClass()
+    obj.method()
+
+
+def helper():
+    pass


### PR DESCRIPTION
For ML applications, it might be useful to capture import information of files (`CodeAssembly` or `CodeCompilationUnit`) and also function calls of a `ControlElement` (but only by name, not by fully qualified resolution). Summary of changes:

- Add `importedModuleNames` to `CodeAssmebly` and `CodeCompilationUnit`
- Add extraction based on AST for Java JDT, Java ANTLR4, and Python ANTLR4
- Note: I also considered constructor calls to be considered in this "function calls" list. It might be debatable whether this is a function call by name, but I wanted to include this information here

Out of scope:

- Extraction of imports and calls for ANTLR4 C++, because I don't know C++ syntax
- Imports in Shell extractor are also set to empty list