### PR TITLE
Add nullable annotations

### DIFF
--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/entity/CodeEntity.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/entity/CodeEntity.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024-2025. */
+/* Licensed under MIT 2024-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.entity;
 
 import java.io.Serial;
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents an entity that is part of the code model.
@@ -19,7 +20,7 @@ public non-sealed class CodeEntity extends ModelEntity {
      *
      * @param name the name of the code entity
      */
-    protected CodeEntity(String name) {
+    protected CodeEntity(@Nullable String name) {
         super(name);
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/entity/ModelEntity.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/entity/ModelEntity.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.entity;
 
 import java.io.Serial;
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.common.util.CommonUtilities;
 
@@ -23,7 +24,7 @@ public abstract sealed class ModelEntity extends Entity permits ArchitectureEnti
      *
      * @param name the name of the entity to be created
      */
-    protected ModelEntity(String name) {
+    protected ModelEntity(@Nullable String name) {
         super(name);
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/Model.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/Model.java
@@ -4,6 +4,8 @@ package edu.kit.kastel.mcse.ardoco.core.api.models;
 import java.util.List;
 import java.util.SortedSet;
 
+import org.jspecify.annotations.Nullable;
+
 import edu.kit.kastel.mcse.ardoco.core.api.entity.ModelEntity;
 import edu.kit.kastel.mcse.ardoco.core.common.IdentifierProvider;
 
@@ -26,7 +28,7 @@ public abstract sealed class Model permits ArchitectureModel, CodeModel {
      *
      * @param id the model id
      */
-    protected Model(String id) {
+    protected Model(@Nullable String id) {
         this.id = id != null ? id : IdentifierProvider.createId();
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/ModelStates.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/ModelStates.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models;
 
 import java.io.Serial;
@@ -6,6 +6,8 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.data.PipelineStepData;
 
@@ -47,7 +49,7 @@ public final class ModelStates implements PipelineStepData {
      * @param id the id
      * @return the corresponding {@link Model}
      */
-    public Model getModel(Metamodel id) {
+    public @Nullable Model getModel(Metamodel id) {
         return this.models.get(id);
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/architecture/dto/ComponentDto.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/architecture/dto/ComponentDto.java
@@ -3,6 +3,8 @@ package edu.kit.kastel.mcse.ardoco.core.api.models.architecture.dto;
 
 import java.util.SortedSet;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.architecture.ArchitectureComponent;
@@ -17,7 +19,7 @@ import edu.kit.kastel.mcse.ardoco.core.api.models.architecture.ArchitectureCompo
  * @param providedInterfacesIds IDs of provided interfaces
  * @param requiredInterfacesIds IDs of required interfaces
  */
-public record ComponentDto(@JsonProperty String id, @JsonProperty String name, @JsonProperty String componentType,
+public record ComponentDto(@JsonProperty String id, @JsonProperty String name, @JsonProperty @Nullable String componentType,
                            @JsonProperty SortedSet<String> subcomponentsIds, @JsonProperty SortedSet<String> providedInterfacesIds,
                            @JsonProperty SortedSet<String> requiredInterfacesIds) implements ArchitectureItemDto {
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeAssembly.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -23,7 +25,7 @@ public final class CodeAssembly extends CodeModule {
     private String language;
 
     @JsonProperty
-    private List<String> importedModuleNames;
+    private @Nullable List<String> importedModuleNames;
 
     /**
      * Default constructor for Jackson.
@@ -67,7 +69,7 @@ public final class CodeAssembly extends CodeModule {
      * @param importedModuleNames the names of imported modules declared in this assembly
      */
     public CodeAssembly(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, String language,
-            List<String> importedModuleNames) {
+            @Nullable List<String> importedModuleNames) {
         super(codeItemRepository, name, content);
         this.language = language;
         this.importedModuleNames = importedModuleNames != null ? new ArrayList<>(importedModuleNames) : new ArrayList<>();

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeCompilationUnit.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -28,7 +30,7 @@ public final class CodeCompilationUnit extends CodeModule {
     @JsonProperty
     private ProgrammingLanguage language;
     @JsonProperty
-    private List<String> importedModuleNames;
+    private @Nullable List<String> importedModuleNames;
 
     /**
      * Default constructor for Jackson.
@@ -50,7 +52,7 @@ public final class CodeCompilationUnit extends CodeModule {
      * @param importedModuleNames the names of imported modules declared in this compilation unit
      */
     public CodeCompilationUnit(CodeItemRepository codeItemRepository, String name, SortedSet<? extends CodeItem> content, List<String> pathElements,
-            String extension, ProgrammingLanguage language, List<String> importedModuleNames) {
+            String extension, ProgrammingLanguage language, @Nullable List<String> importedModuleNames) {
         super(codeItemRepository, name, content);
         this.pathElements = new ArrayList<>(pathElements);
         this.extension = extension;
@@ -69,7 +71,7 @@ public final class CodeCompilationUnit extends CodeModule {
      * @return a new CodeCompilationUnit with name, pathElements, and extension derived from the path
      */
     public static CodeCompilationUnit fromRelativePath(CodeItemRepository codeItemRepository, SortedSet<? extends CodeItem> content,
-            ProgrammingLanguage language, String relativePath, List<String> importedModuleNames) {
+            ProgrammingLanguage language, String relativePath, @Nullable List<String> importedModuleNames) {
         int lastSlash = relativePath.lastIndexOf('/');
         int lastDot = relativePath.lastIndexOf('.');
         String name = relativePath.substring(lastSlash + 1, lastDot > lastSlash ? lastDot : relativePath.length());

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeItem.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeItem.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -31,7 +33,7 @@ public abstract sealed class CodeItem extends CodeEntity permits CodeModule, Com
 
     @JsonIgnore
     protected CodeItemRepository codeItemRepository;
-    protected String comment;
+    protected @Nullable String comment;
 
     CodeItem() {
         // Jackson
@@ -121,7 +123,7 @@ public abstract sealed class CodeItem extends CodeEntity permits CodeModule, Com
         return new TreeSet<>();
     }
 
-    public String getComment() {
+    public @Nullable String getComment() {
         return this.comment;
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeItemRepository.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeItemRepository.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,7 +43,8 @@ public class CodeItemRepository implements Serializable {
         return this.repository.containsKey(id);
     }
 
-    CodeItem getCodeItem(String id) {
+    @Nullable
+    CodeItem getCodeItem(@Nullable String id) {
         if (id == null) {
             return null;
         }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeModule.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/CodeModule.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.models.code;
 
 import java.io.Serial;
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,7 +32,7 @@ public sealed class CodeModule extends CodeItem permits CodeAssembly, CodeCompil
     private static final long serialVersionUID = -7941299662945801101L;
 
     @JsonProperty
-    private String parentId;
+    private @Nullable String parentId;
     @JsonProperty
     private List<String> content;
 
@@ -109,7 +111,7 @@ public sealed class CodeModule extends CodeItem permits CodeAssembly, CodeCompil
      *
      * @return parent code module, or null if none
      */
-    public CodeModule getParent() {
+    public @Nullable CodeModule getParent() {
         CodeItem codeItem = this.codeItemRepository.getCodeItem(this.parentId);
         if (codeItem instanceof CodeModule codeModule) {
             return codeModule;

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/ControlElement.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -26,7 +28,7 @@ public final class ControlElement extends ComputationalObject {
     private int endLine = -1;
 
     @JsonProperty
-    private List<String> calleeNames;
+    private @Nullable List<String> calleeNames;
 
     /**
      * Default constructor for Jackson.
@@ -55,7 +57,7 @@ public final class ControlElement extends ComputationalObject {
      * @param endLine            the 1-indexed end line in the source file, or -1 if unknown
      * @param calleeNames        the names of the callees of this control element
      */
-    public ControlElement(CodeItemRepository codeItemRepository, String name, int startLine, int endLine, List<String> calleeNames) {
+    public ControlElement(CodeItemRepository codeItemRepository, String name, int startLine, int endLine, @Nullable List<String> calleeNames) {
         super(codeItemRepository, name);
         this.startLine = startLine;
         this.endLine = endLine;

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/models/code/Datatype.java
@@ -9,6 +9,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -30,9 +32,9 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
     private static final long serialVersionUID = -1925023806648753973L;
 
     @JsonProperty
-    private String compilationUnitId;
+    private @Nullable String compilationUnitId;
     @JsonProperty
-    private String parentDatatypeId;
+    private @Nullable String parentDatatypeId;
     @JsonProperty
     private int startLine = -1;
     @JsonProperty
@@ -42,7 +44,7 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
     @JsonProperty
     private List<String> implementedDataTypesIds;
     @JsonProperty
-    private List<String> datatypeReferencesIds;
+    private @Nullable List<String> datatypeReferencesIds;
     @JsonProperty
     private List<String> content;
 
@@ -106,7 +108,7 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
      *
      * @return the compilation unit, or null if not set
      */
-    public CodeCompilationUnit getCompilationUnit() {
+    public @Nullable CodeCompilationUnit getCompilationUnit() {
         CodeItem codeItem = this.codeItemRepository.getCodeItem(this.compilationUnitId);
         if (codeItem instanceof CodeCompilationUnit codeCompilationUnit) {
             return codeCompilationUnit;
@@ -119,7 +121,7 @@ public sealed class Datatype extends CodeItem permits ClassUnit, InterfaceUnit {
      *
      * @return the parent datatype, or null if not set
      */
-    public Datatype getParentDatatype() {
+    public @Nullable Datatype getParentDatatype() {
         CodeItem codeItem = this.codeItemRepository.getCodeItem(this.parentDatatypeId);
         if (codeItem instanceof Datatype datatype) {
             return datatype;

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/connectiongenerator/ConnectionStates.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/connectiongenerator/ConnectionStates.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.connectiongenerator;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.data.PipelineStepData;
@@ -19,5 +21,6 @@ public interface ConnectionStates extends PipelineStepData {
      * @param metamodel the metamodel
      * @return the connection state
      */
+    @Nullable
     ConnectionState getConnectionState(Metamodel metamodel);
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/connectiongenerator/ner/NerConnectionStates.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/connectiongenerator/ner/NerConnectionStates.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.connectiongenerator.ner;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.data.PipelineStepData;
@@ -19,5 +21,6 @@ public interface NerConnectionStates extends PipelineStepData {
      * @param metamodel the metamodel
      * @return the connection state
      */
+    @Nullable
     NerConnectionState getNerConnectionState(Metamodel metamodel);
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/inconsistency/InconsistencyStates.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/inconsistency/InconsistencyStates.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.inconsistency;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.data.PipelineStepData;
@@ -19,5 +21,6 @@ public interface InconsistencyStates extends PipelineStepData {
      * @param metamodel the metamodel
      * @return the inconsistency state
      */
+    @Nullable
     InconsistencyState getInconsistencyState(Metamodel metamodel);
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/recommendationgenerator/RecommendationState.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/recommendationgenerator/RecommendationState.java
@@ -1,7 +1,8 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator;
 
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.NounMapping;
 import edu.kit.kastel.mcse.ardoco.core.configuration.IConfigurable;
@@ -49,6 +50,6 @@ public interface RecommendationState extends IConfigurable {
      * @param nounMapping the noun mapping to delete
      * @param replacement the replacement noun mapping
      */
-    void onNounMappingDeletion(NounMapping nounMapping, NounMapping replacement);
+    void onNounMappingDeletion(NounMapping nounMapping, @Nullable NounMapping replacement);
 
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/recommendationgenerator/RecommendationStates.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/recommendationgenerator/RecommendationStates.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.data.PipelineStepData;
@@ -19,5 +21,6 @@ public interface RecommendationStates extends PipelineStepData {
      * @param metamodel the metamodel
      * @return the recommendation state
      */
+    @Nullable
     RecommendationState getRecommendationState(Metamodel metamodel);
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/recommendationgenerator/RecommendedInstance.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/recommendationgenerator/RecommendedInstance.java
@@ -1,9 +1,10 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator;
 
 import java.io.Serial;
 
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.entity.TextEntity;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.NounMapping;
@@ -99,5 +100,5 @@ public abstract class RecommendedInstance extends TextEntity {
      * @param nounMapping the noun mapping to delete
      * @param replacement the replacement noun mapping
      */
-    public abstract void onNounMappingDeletion(NounMapping nounMapping, NounMapping replacement);
+    public abstract void onNounMappingDeletion(NounMapping nounMapping, @Nullable NounMapping replacement);
 }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/textextraction/TextState.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/textextraction/TextState.java
@@ -1,8 +1,9 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.Word;
 import edu.kit.kastel.mcse.ardoco.core.configuration.IConfigurable;
@@ -30,7 +31,7 @@ public interface TextState extends IConfigurable, PipelineStepData {
      * @param replacement    the replacement noun mapping (optional)
      * @param cascade        whether to cascade the removal
      */
-    void removeNounMapping(DataRepository dataRepository, NounMapping nounMapping, NounMapping replacement, boolean cascade);
+    void removeNounMapping(DataRepository dataRepository, NounMapping nounMapping, @Nullable NounMapping replacement, boolean cascade);
 
     /**
      * Adds a phrase mapping to the state.
@@ -94,7 +95,7 @@ public interface TextState extends IConfigurable, PipelineStepData {
      * @param kind the mapping kind
      * @return the noun mappings that could be of the specified kind
      */
-    default ImmutableList<NounMapping> getMappingsThatCouldBeOfKind(Word word, MappingKind kind) {
+    default ImmutableList<NounMapping> getMappingsThatCouldBeOfKind(@Nullable Word word, MappingKind kind) {
         return this.getNounMappingsByWord(word).select(mapping -> mapping.getProbabilityForKind(kind) > 0);
     }
 
@@ -105,7 +106,7 @@ public interface TextState extends IConfigurable, PipelineStepData {
      * @param kinds the mapping kinds
      * @return the noun mappings that could be of multiple specified kinds
      */
-    ImmutableList<NounMapping> getMappingsThatCouldBeMultipleKinds(Word word, MappingKind... kinds);
+    ImmutableList<NounMapping> getMappingsThatCouldBeMultipleKinds(@Nullable Word word, MappingKind... kinds);
 
     /**
      * Retrieves noun mappings associated with the given word.
@@ -113,7 +114,7 @@ public interface TextState extends IConfigurable, PipelineStepData {
      * @param word the word
      * @return the noun mappings associated with the word
      */
-    default ImmutableList<NounMapping> getNounMappingsByWord(Word word) {
+    default ImmutableList<NounMapping> getNounMappingsByWord(@Nullable Word word) {
         return this.getNounMappings().select(nm -> nm.getWords().contains(word));
     }
 
@@ -124,7 +125,7 @@ public interface TextState extends IConfigurable, PipelineStepData {
      * @param kind the mapping kind
      * @return the noun mappings associated with the word and of the specified kind
      */
-    default ImmutableList<NounMapping> getNounMappingsByWordAndKind(Word word, MappingKind kind) {
+    default ImmutableList<NounMapping> getNounMappingsByWordAndKind(@Nullable Word word, MappingKind kind) {
         return this.getNounMappings().select(n -> n.getWords().contains(word)).select(this.nounMappingIsOfKind(kind)).toImmutable();
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/textextraction/TextStateStrategy.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/stage/textextraction/TextStateStrategy.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction;
 
 import static edu.kit.kastel.mcse.ardoco.core.common.AggregationFunctions.AVERAGE;
@@ -8,6 +8,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.Word;
 import edu.kit.kastel.mcse.ardoco.core.common.AggregationFunctions;
@@ -61,7 +62,7 @@ public interface TextStateStrategy {
      * @return the new or merged mapping
      */
     NounMapping addNounMapping(ImmutableSortedSet<Word> words, ImmutableSortedMap<MappingKind, Confidence> distribution, ImmutableList<Word> referenceWords,
-            ImmutableList<String> surfaceForms, String reference);
+            ImmutableList<String> surfaceForms, @Nullable String reference);
 
     /**
      * Adds a noun mapping of the specified kind to the state that contains the specified words, surface forms, etc.
@@ -76,7 +77,7 @@ public interface TextStateStrategy {
      * @return the new or merged mapping
      */
     NounMapping addNounMapping(ImmutableSortedSet<Word> words, MappingKind kind, Claimant claimant, double probability, ImmutableList<Word> referenceWords,
-            ImmutableList<String> surfaceForms, String reference);
+            ImmutableList<String> surfaceForms, @Nullable String reference);
 
     /**
      * Merges two noun mappings into a new mapping of the given kind, probability and claimant without adding it to the state.
@@ -90,8 +91,8 @@ public interface TextStateStrategy {
      * @param probability       the probability
      * @return the merged noun mapping
      */
-    NounMapping mergeNounMappingsStateless(NounMapping firstNounMapping, NounMapping secondNounMapping, ImmutableList<Word> referenceWords, String reference,
-            MappingKind mappingKind, Claimant claimant, double probability);
+    NounMapping mergeNounMappingsStateless(NounMapping firstNounMapping, NounMapping secondNounMapping, @Nullable ImmutableList<Word> referenceWords,
+            @Nullable String reference, MappingKind mappingKind, Claimant claimant, double probability);
 
     /**
      * Merges two noun mappings into a new mapping of the given kind, probability and claimant and adds it to the state.
@@ -105,8 +106,8 @@ public interface TextStateStrategy {
      * @param probability       the probability
      * @return the merged noun mapping
      */
-    NounMapping mergeNounMappings(NounMapping firstNounMapping, NounMapping secondNounMapping, ImmutableList<Word> referenceWords, String reference,
-            MappingKind mappingKind, Claimant claimant, double probability);
+    NounMapping mergeNounMappings(NounMapping firstNounMapping, NounMapping secondNounMapping, @Nullable ImmutableList<Word> referenceWords,
+            @Nullable String reference, MappingKind mappingKind, Claimant claimant, double probability);
 
     /**
      * Calculates a joined reference for a set of reference words.

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/text/Sentence.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/text/Sentence.java
@@ -1,9 +1,10 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.text;
 
 import java.io.Serializable;
 
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a sentence in the document.
@@ -37,7 +38,7 @@ public interface Sentence extends Serializable {
      * @param other the other sentence
      * @return true if equal
      */
-    default boolean isEqualTo(Sentence other) {
+    default boolean isEqualTo(@Nullable Sentence other) {
         return other != null && this.getSentenceNumber() == other.getSentenceNumber() && other.getText().equals(this.getText());
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/text/Word.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/text/Word.java
@@ -1,9 +1,10 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.text;
 
 import java.io.Serializable;
 
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a word in a text.
@@ -43,6 +44,7 @@ public interface Word extends Comparable<Word>, Serializable {
      *
      * @return the previous word
      */
+    @Nullable
     Word getPreWord();
 
     /**
@@ -50,6 +52,7 @@ public interface Word extends Comparable<Word>, Serializable {
      *
      * @return the next word
      */
+    @Nullable
     Word getNextWord();
 
     /**

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/tracelink/MultiHopTransitiveTraceLink.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/tracelink/MultiHopTransitiveTraceLink.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024-2025. */
+/* Licensed under MIT 2024-2026. */
 package edu.kit.kastel.mcse.ardoco.core.api.tracelink;
 
 import java.io.Serial;
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public final class MultiHopTransitiveTraceLink<A extends Entity, B extends Entit
     }
 
     public static <A extends Entity, B extends Entity> Optional<MultiHopTransitiveTraceLink<A, B>> createTransitiveTraceLink(TraceLink<A, ?> firstTraceLink,
-            TraceLink<?, B> lastTraceLink, List<? extends TraceLink<?, ?>> intermediateLinks) {
+            TraceLink<?, B> lastTraceLink, @Nullable List<? extends TraceLink<?, ?>> intermediateLinks) {
 
         if (intermediateLinks == null || intermediateLinks.isEmpty()) {
             throw new IllegalArgumentException("Please use " + TransitiveTraceLink.class.getSimpleName());

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/similarity/wordsim/ComparisonContext.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/similarity/wordsim/ComparisonContext.java
@@ -3,6 +3,8 @@ package edu.kit.kastel.mcse.ardoco.core.common.similarity.wordsim;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import edu.kit.kastel.mcse.ardoco.core.api.text.Word;
 
 /**
@@ -10,7 +12,7 @@ import edu.kit.kastel.mcse.ardoco.core.api.text.Word;
  * The fields {@code firstString} and {@code secondString} are always non-null.
  * The field {@code lemmatize} decides whether the lemmatized version of both words should be used for comparison.
  */
-public record ComparisonContext(String firstString, String secondString, Word firstWord, Word secondWord, boolean lemmatize) {
+public record ComparisonContext(String firstString, String secondString, @Nullable Word firstWord, @Nullable Word secondWord, boolean lemmatize) {
 
     /**
      * Constructs a string-based context with the default match function and no lemmatization.
@@ -62,7 +64,7 @@ public record ComparisonContext(String firstString, String secondString, Word fi
         return this.findAppropriateTerm(this.secondString, this.secondWord);
     }
 
-    private String findAppropriateTerm(String string, Word word) {
+    private String findAppropriateTerm(String string, @Nullable Word word) {
         Objects.requireNonNull(string);
 
         if (word != null) {

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/DataRepositoryHelper.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/DataRepositoryHelper.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.common.util;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.InputTextData;
 import edu.kit.kastel.mcse.ardoco.core.api.PreprocessingData;
@@ -217,7 +219,7 @@ public final class DataRepositoryHelper {
      * @param dataRepository the DataRepository to access
      * @return the state
      */
-    public static InconsistencyStates getInconsistencyStates(DataRepository dataRepository) {
+    public static @Nullable InconsistencyStates getInconsistencyStates(DataRepository dataRepository) {
         if (hasInconsistencyStates(dataRepository)) {
             return dataRepository.getData(InconsistencyStates.ID, InconsistencyStates.class).orElseThrow();
         }
@@ -242,7 +244,7 @@ public final class DataRepositoryHelper {
      * @param dataRepository the DataRepository to access
      * @return the state
      */
-    public static CodeTraceabilityState getCodeTraceabilityState(DataRepository dataRepository) {
+    public static @Nullable CodeTraceabilityState getCodeTraceabilityState(DataRepository dataRepository) {
         if (hasCodeTraceabilityState(dataRepository)) {
             return dataRepository.getData(CodeTraceabilityState.ID, CodeTraceabilityState.class).orElseThrow();
         }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/Environment.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/Environment.java
@@ -1,9 +1,10 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.core.common.util;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ import io.github.cdimascio.dotenv.Dotenv;
 public final class Environment {
     private static final Logger logger = LoggerFactory.getLogger(Environment.class);
     /** The loaded .env configuration, or null if no .env file exists */
-    private static final Dotenv DOTENV = load();
+    private static final @Nullable Dotenv DOTENV = load();
 
     private Environment() {
         throw new IllegalAccessError("Utility class");
@@ -51,7 +52,7 @@ public final class Environment {
      * @param key The name of the environment variable to retrieve
      * @return The value of the environment variable, or null if not found
      */
-    public static String getEnv(String key) {
+    public static @Nullable String getEnv(String key) {
         String dotenvValue = DOTENV == null ? null : DOTENV.get(key);
         if (dotenvValue != null)
             return dotenvValue;
@@ -71,7 +72,7 @@ public final class Environment {
      * @return The value of the environment variable
      * @throws IllegalStateException if the variable is not found and strict mode is enabled
      */
-    public static String getEnvNonNull(String key) {
+    public static @Nullable String getEnvNonNull(String key) {
         String env = getEnv(key);
         if (env == null) {
             logger.error("environment variable {} is missing, use '.env' or your system to set it up", key);
@@ -92,7 +93,7 @@ public final class Environment {
      *
      * @return The loaded Dotenv configuration, or null if no .env file exists
      */
-    private static synchronized Dotenv load() {
+    private static synchronized @Nullable Dotenv load() {
         if (DOTENV != null) {
             return DOTENV;
         }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/ResourceAccessor.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/common/util/ResourceAccessor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.core.common.util;
 
 import java.io.FileInputStream;
@@ -8,6 +8,7 @@ import java.util.Properties;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,7 @@ public final class ResourceAccessor {
      * @param key name of the specified property
      * @return value of the property as a string, or null if not found
      */
-    public String getProperty(String key) {
+    public @Nullable String getProperty(String key) {
         return this.prop.getProperty(key);
     }
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/AbstractConfigurable.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/AbstractConfigurable.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.configuration;
 
 import java.lang.reflect.Field;
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.eclipse.collections.api.factory.SortedMaps;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public abstract class AbstractConfigurable implements IConfigurable {
     public static final String LIST_SEPARATOR = ",";
 
     @SuppressWarnings("java:S2065") // The logger is used in the subclasses that are serializable
-    private transient Logger logger;
+    private transient @Nullable Logger logger;
 
     private ImmutableSortedMap<String, String> lastAppliedConfiguration = SortedMaps.immutable.empty();
 

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/ConfigurationInstantiatorUtils.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/configuration/ConfigurationInstantiatorUtils.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.core.configuration;
 
 import java.lang.reflect.Constructor;
@@ -8,6 +8,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.architecture.Deterministic;
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
@@ -74,8 +76,8 @@ public final class ConfigurationInstantiatorUtils {
         return (AbstractConfigurable) c.newInstance(arguments);
     }
 
-    private static AbstractConfigurable findAndCreate(Collection<Constructor<?>> constructors, Predicate<Constructor<?>> selector, Object[] parameters)
-            throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    private static @Nullable AbstractConfigurable findAndCreate(Collection<Constructor<?>> constructors, Predicate<Constructor<?>> selector,
+            Object[] parameters) throws InvocationTargetException, InstantiationException, IllegalAccessException {
         if (constructors.stream().noneMatch(selector)) {
             return null;
         }

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/data/DataRepositorySyncer.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/data/DataRepositorySyncer.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2024-2025. */
+/* Licensed under MIT 2024-2026. */
 package edu.kit.kastel.mcse.ardoco.core.data;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator.RecommendationStates;
@@ -20,7 +22,7 @@ public final class DataRepositorySyncer {
      * @param nounMapping    the noun mapping to delete
      * @param replacement    the replacement noun mapping, if any
      */
-    public static void onNounMappingDeletion(DataRepository dataRepository, NounMapping nounMapping, NounMapping replacement) {
+    public static void onNounMappingDeletion(DataRepository dataRepository, NounMapping nounMapping, @Nullable NounMapping replacement) {
         // We need to inform the recommendation state
         var recommendationStates = dataRepository.getData(RecommendationStates.ID, RecommendationStates.class);
         if (recommendationStates.isEmpty()) {

--- a/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/data/PipelineStepData.java
+++ b/core/framework/common/src/main/java/edu/kit/kastel/mcse/ardoco/core/data/PipelineStepData.java
@@ -1,9 +1,10 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.data;
 
 import java.io.Serializable;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public interface PipelineStepData extends Serializable {
      *
      * @return JSON string representation of this data or null if serialization fails.
      */
-    default String serialize() {
+    default @Nullable String serialize() {
         var oom = JsonHandling.createObjectMapper();
         try {
             return oom.writeValueAsString(this);
@@ -55,7 +56,7 @@ public interface PipelineStepData extends Serializable {
      * @param data JSON string to deserialize
      * @return Deserialized instance of this data type or null if deserialization fails.
      */
-    default PipelineStepData deserialize(String data) {
+    default @Nullable PipelineStepData deserialize(String data) {
         var oom = JsonHandling.createObjectMapper();
         try {
             return oom.readValue(data, this.getClass());

--- a/core/framework/text-provider-json/src/main/java/edu/kit/kastel/mcse/ardoco/core/textproviderjson/textobject/PhraseImpl.java
+++ b/core/framework/text-provider-json/src/main/java/edu/kit/kastel/mcse/ardoco/core/textproviderjson/textobject/PhraseImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.textproviderjson.textobject;
 
 import java.io.Serial;
@@ -13,6 +13,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.Phrase;
 import edu.kit.kastel.mcse.ardoco.core.api.text.PhraseType;
@@ -28,14 +29,14 @@ public class PhraseImpl implements Phrase {
     private final PhraseType type;
     private MutableList<Phrase> childPhrases;
     private MutableList<Word> nonPhraseWords;
-    private MutableList<Word> phraseWords;
-    private MutableList<Word> containedWords;
-    private MutableList<Phrase> subphrases;
-    private MutableSortedMap<Word, Integer> phraseVector;
+    private @Nullable MutableList<Word> phraseWords;
+    private @Nullable MutableList<Word> containedWords;
+    private @Nullable MutableList<Phrase> subphrases;
+    private @Nullable MutableSortedMap<Word, Integer> phraseVector;
     private int sentenceNo = -1;
-    private String text;
+    private @Nullable String text;
 
-    public PhraseImpl(ImmutableList<Word> nonPhraseWords, PhraseType type, List<Phrase> childPhrases) {
+    public PhraseImpl(@Nullable ImmutableList<Word> nonPhraseWords, PhraseType type, List<Phrase> childPhrases) {
         this.nonPhraseWords = nonPhraseWords == null ? Lists.mutable.empty() : nonPhraseWords.toList();
         this.type = type;
         this.childPhrases = Lists.mutable.ofAll(childPhrases);

--- a/core/framework/text-provider-json/src/main/java/edu/kit/kastel/mcse/ardoco/core/textproviderjson/textobject/SentenceImpl.java
+++ b/core/framework/text-provider-json/src/main/java/edu/kit/kastel/mcse/ardoco/core/textproviderjson/textobject/SentenceImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.textproviderjson.textobject;
 
 import java.io.Serial;
@@ -9,6 +9,7 @@ import java.util.Objects;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.Phrase;
 import edu.kit.kastel.mcse.ardoco.core.api.text.Sentence;
@@ -25,7 +26,7 @@ public class SentenceImpl implements Sentence {
 
     private final String text;
 
-    public SentenceImpl(int sentenceNumber, String text, ImmutableList<Word> words) {
+    public SentenceImpl(int sentenceNumber, String text, @Nullable ImmutableList<Word> words) {
         this.sentenceNumber = sentenceNumber;
         this.text = text;
         this.words = words == null ? Lists.mutable.empty() : words.toList();

--- a/core/framework/text-provider-json/src/main/java/edu/kit/kastel/mcse/ardoco/core/textproviderjson/textobject/WordImpl.java
+++ b/core/framework/text-provider-json/src/main/java/edu/kit/kastel/mcse/ardoco/core/textproviderjson/textobject/WordImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.core.textproviderjson.textobject;
 
 import java.io.Serial;
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.DependencyTag;
 import edu.kit.kastel.mcse.ardoco.core.api.text.POSTag;
@@ -21,11 +22,11 @@ public class WordImpl implements Word {
     private static final long serialVersionUID = 411612592257031380L;
     private final Text parent;
     private final int indexInText;
-    private Word preWord;
-    private Word nextWord;
+    private @Nullable Word preWord;
+    private @Nullable Word nextWord;
 
     private final int sentenceNo;
-    private Phrase phrase;
+    private @Nullable Phrase phrase;
     private final String text;
     private final POSTag posTag;
     private final String lemma;
@@ -68,7 +69,7 @@ public class WordImpl implements Word {
     }
 
     @Override
-    public Word getPreWord() {
+    public @Nullable Word getPreWord() {
         int preWordIndex = indexInText - 1;
         if (preWord == null && preWordIndex > 0) {
             preWord = parent.getWord(preWordIndex);
@@ -77,7 +78,7 @@ public class WordImpl implements Word {
     }
 
     @Override
-    public Word getNextWord() {
+    public @Nullable Word getNextWord() {
         int nextWordIndex = indexInText + 1;
         if (nextWord == null && nextWordIndex < parent.getNumberOfWords()) {
             nextWord = parent.getWord(nextWordIndex);

--- a/core/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArdocoResult.java
+++ b/core/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/api/output/ArdocoResult.java
@@ -12,6 +12,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.MutableSet;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -234,7 +235,7 @@ public record ArdocoResult(DataRepository dataRepository) {
      * @param metamodel the metamodel to get the connection state for
      * @return the connection state or null if there is no {@link ConnectionState} for the given metamodel
      */
-    public ConnectionState getConnectionState(Metamodel metamodel) {
+    public @Nullable ConnectionState getConnectionState(Metamodel metamodel) {
         if (DataRepositoryHelper.hasConnectionStates(this.dataRepository)) {
             var connectionStates = DataRepositoryHelper.getConnectionStates(this.dataRepository);
             return connectionStates.getConnectionState(metamodel);
@@ -249,7 +250,7 @@ public record ArdocoResult(DataRepository dataRepository) {
      * @param metamodel the metamodel to get the connection state for
      * @return the connection state or null if there is no {@link ConnectionState} for the given metamodel
      */
-    public NerConnectionState getNerConnectionState(Metamodel metamodel) {
+    public @Nullable NerConnectionState getNerConnectionState(Metamodel metamodel) {
         if (DataRepositoryHelper.hasNerConnectionStates(this.dataRepository)) {
             var connectionStates = DataRepositoryHelper.getNerConnectionStates(this.dataRepository);
             return connectionStates.getNerConnectionState(metamodel);
@@ -264,7 +265,7 @@ public record ArdocoResult(DataRepository dataRepository) {
      * @param metamodel the metamodel to get the inconsistency state for
      * @return the inconsistency state or null if there is no {@link InconsistencyState} for the given metamodel
      */
-    public InconsistencyState getInconsistencyState(Metamodel metamodel) {
+    public @Nullable InconsistencyState getInconsistencyState(Metamodel metamodel) {
         if (DataRepositoryHelper.hasInconsistencyStates(this.dataRepository)) {
             var inconsistencyStates = DataRepositoryHelper.getInconsistencyStates(this.dataRepository);
             return inconsistencyStates.getInconsistencyState(metamodel);
@@ -278,7 +279,7 @@ public record ArdocoResult(DataRepository dataRepository) {
      *
      * @return the {@link CodeTraceabilityState} or null if there is no {@link CodeTraceabilityState}
      */
-    public CodeTraceabilityState getCodeTraceabilityState() {
+    public @Nullable CodeTraceabilityState getCodeTraceabilityState() {
         if (DataRepositoryHelper.hasCodeTraceabilityState(this.dataRepository)) {
             return DataRepositoryHelper.getCodeTraceabilityState(this.dataRepository);
         }

--- a/core/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/execution/Ardoco.java
+++ b/core/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/execution/Ardoco.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,7 @@ public final class Ardoco extends Pipeline {
      * @param outputDir the directory where output files should be saved
      * @return the ARDoCo result containing all analysis data, or null if the pipeline is not properly initialized
      */
-    public ArdocoResult runAndSave(File outputDir) {
+    public @Nullable ArdocoResult runAndSave(File outputDir) {
         classLogger.info("Starting {}", this.projectName);
 
         if (!this.hasPipelineSteps()) {

--- a/core/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/execution/ConfigurationHelper.java
+++ b/core/pipeline-core/src/main/java/edu/kit/kastel/mcse/ardoco/core/execution/ConfigurationHelper.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.eclipse.collections.api.factory.SortedMaps;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
+import org.jspecify.annotations.Nullable;
 import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +40,7 @@ public class ConfigurationHelper {
      * @param additionalConfigsFile the file containing the additional configurations
      * @return a map with the additional configurations
      */
-    public static ImmutableSortedMap<String, String> loadAdditionalConfigs(File additionalConfigsFile) {
+    public static ImmutableSortedMap<String, String> loadAdditionalConfigs(@Nullable File additionalConfigsFile) {
         MutableSortedMap<String, String> additionalConfigs = SortedMaps.mutable.empty();
         if (additionalConfigsFile != null && (!additionalConfigsFile.exists() || !additionalConfigsFile.isFile())) {
             throw new IllegalArgumentException("File " + additionalConfigsFile.getAbsolutePath() + " is not a valid configuration file!");

--- a/inconsistency-detection/stages-id/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/id/InconsistencyStatesImpl.java
+++ b/inconsistency-detection/stages-id/inconsistency-detection/src/main/java/edu/kit/kastel/mcse/ardoco/id/InconsistencyStatesImpl.java
@@ -1,8 +1,10 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.id;
 
 import java.io.Serial;
 import java.util.EnumMap;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.inconsistency.InconsistencyState;
@@ -26,7 +28,7 @@ public class InconsistencyStatesImpl implements InconsistencyStates {
     }
 
     @Override
-    public InconsistencyState getInconsistencyState(Metamodel metamodel) {
+    public @Nullable InconsistencyState getInconsistencyState(Metamodel metamodel) {
         return inconsistencyStates.get(metamodel);
     }
 }

--- a/inconsistency-detection/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/id/tests/integration/inconsistencyhelper/HoldBackRunResultsProducer.java
+++ b/inconsistency-detection/tests-inconsistency/src/test/java/edu/kit/kastel/mcse/ardoco/id/tests/integration/inconsistencyhelper/HoldBackRunResultsProducer.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.NonNull;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.ModelFormat;
 import edu.kit.kastel.mcse.ardoco.core.api.models.architecture.ArchitectureItem;
@@ -81,7 +82,7 @@ public class HoldBackRunResultsProducer {
             boolean useInconsistencyBaseline) {
         return new AnonymousRunner(goldStandardProject.name()) {
             @Override
-            public List<AbstractPipelineStep> initializePipelineSteps(DataRepository dataRepository) {
+            public @NonNull List<AbstractPipelineStep> initializePipelineSteps(@NonNull DataRepository dataRepository) {
                 var pipelineSteps = new ArrayList<AbstractPipelineStep>();
 
                 var text = CommonUtilities.readInputText(HoldBackRunResultsProducer.this.inputText);

--- a/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/ArchitectureLinkToCodeLinkTransformerInformant.java
+++ b/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/ArchitectureLinkToCodeLinkTransformerInformant.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants;
 
 import java.util.ArrayList;
@@ -7,6 +7,7 @@ import java.util.List;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.set.MutableSet;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.entity.ModelEntity;
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModelWithCompilationUnitsAndPackages;
@@ -110,7 +111,7 @@ public class ArchitectureLinkToCodeLinkTransformerInformant extends Informant {
         throw new IllegalStateException("Could not find model element " + modelElementId);
     }
 
-    private CodeModelWithCompilationUnitsAndPackages findCoarseGrainedCodeModel(ModelStates models) {
+    private @Nullable CodeModelWithCompilationUnitsAndPackages findCoarseGrainedCodeModel(ModelStates models) {
         for (var metamodel : models.getMetamodels()) {
             var model = models.getModel(metamodel);
             if (model instanceof CodeModelWithCompilationUnitsAndPackages codeModel) {

--- a/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/TraceLinkGenerator.java
+++ b/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/TraceLinkGenerator.java
@@ -1,9 +1,11 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.ArchitectureModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
@@ -110,7 +112,7 @@ public final class TraceLinkGenerator {
         return Filter.getFilterArchNode(maxCompInterface, new ProvidedInterfaceCorrespondence().getNode(maxCompInterface));
     }
 
-    public static Set<ArchitectureCodeTraceLink> generateTraceLinks(Node root, ArchitectureModel archModel, CodeModel codeModel) {
+    public static Set<ArchitectureCodeTraceLink> generateTraceLinks(@Nullable Node root, @Nullable ArchitectureModel archModel, @Nullable CodeModel codeModel) {
         if (archModel == null || codeModel == null) {
             return new java.util.LinkedHashSet<>();
         }
@@ -122,7 +124,7 @@ public final class TraceLinkGenerator {
         return computation.getTraceLinks();
     }
 
-    public static Set<ArchitectureCodeTraceLink> generateTraceLinks(ArchitectureModel archModel, CodeModel codeModel) {
+    public static Set<ArchitectureCodeTraceLink> generateTraceLinks(@Nullable ArchitectureModel archModel, @Nullable CodeModel codeModel) {
         return generateTraceLinks(getRoot(), archModel, codeModel);
     }
 }

--- a/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/computation/ComputationResult.java
+++ b/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/computation/ComputationResult.java
@@ -1,10 +1,12 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.computation;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.architecture.ArchitectureItem;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeCompilationUnit;
@@ -37,7 +39,7 @@ public class ComputationResult {
      * @param endpointTuple the endpoint tuple for which a confidence is to be returned
      * @return the confidence of the combination of computation node and endpoint tuple, or null if it doesn't exist yet
      */
-    public Confidence getConfidence(Node node, Pair<ArchitectureItem, CodeCompilationUnit> endpointTuple) {
+    public @Nullable Confidence getConfidence(Node node, Pair<ArchitectureItem, CodeCompilationUnit> endpointTuple) {
         if (!this.exists(node)) {
             return null;
         }
@@ -51,7 +53,7 @@ public class ComputationResult {
      * @param node the computation node for which the result is to be returned
      * @return the result of the computation node, or null if it doesn't exist yet
      */
-    public NodeResult getNodeResult(Node node) {
+    public @Nullable NodeResult getNodeResult(Node node) {
         return this.resultMap.get(node);
     }
 

--- a/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/computation/Confidence.java
+++ b/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/computation/Confidence.java
@@ -1,8 +1,10 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.computation;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * The calculated confidence of an endpoint tuple. The confidence has a value
@@ -18,7 +20,7 @@ import java.util.Objects;
  */
 public class Confidence implements Comparable<Confidence> {
 
-    private final Double confidenceValue;
+    private final @Nullable Double confidenceValue;
 
     /**
      * Creates a new confidence that doesn't have a value.

--- a/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/computation/NodeResult.java
+++ b/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/computation/NodeResult.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.computation;
 
 import java.util.LinkedHashMap;
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.entity.Entity;
 import edu.kit.kastel.mcse.ardoco.core.api.models.ArchitectureModel;
@@ -48,7 +50,7 @@ public class NodeResult {
      * @param endpointTuple the endpoint tuple for which the confidence is to be returned
      * @return the confidence of the endpoint tuple, or null if it doesn't exist yet
      */
-    public Confidence getConfidence(Pair<ArchitectureItem, CodeCompilationUnit> endpointTuple) {
+    public @Nullable Confidence getConfidence(Pair<ArchitectureItem, CodeCompilationUnit> endpointTuple) {
         return this.confidenceMap.get(endpointTuple);
     }
 

--- a/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/functions/aggregation/Average.java
+++ b/tlr/stages-tlr/code-traceability/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/codetraceability/informants/arcotl/functions/aggregation/Average.java
@@ -1,9 +1,11 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.functions.aggregation;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.computation.Confidence;
 import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.computation.computationtree.AggregationNode;
@@ -15,7 +17,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.codetraceability.informants.arcotl.computa
  */
 public class Average extends ConfidenceAggregator {
 
-    private final List<Double> weights;
+    private final @Nullable List<Double> weights;
 
     private Average() {
         weights = null;

--- a/tlr/stages-tlr/connection-generator-ner/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/connectiongenerator/ner/NerConnectionStatesImpl.java
+++ b/tlr/stages-tlr/connection-generator-ner/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/connectiongenerator/ner/NerConnectionStatesImpl.java
@@ -1,8 +1,10 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.ner;
 
 import java.io.Serial;
 import java.util.EnumMap;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.connectiongenerator.ner.NerConnectionStates;
@@ -27,7 +29,7 @@ public class NerConnectionStatesImpl implements NerConnectionStates {
     }
 
     @Override
-    public NerConnectionStateImpl getNerConnectionState(Metamodel metamodel) {
+    public @Nullable NerConnectionStateImpl getNerConnectionState(Metamodel metamodel) {
         return connectionStates.get(metamodel);
     }
 

--- a/tlr/stages-tlr/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/connectiongenerator/ConnectionStatesImpl.java
+++ b/tlr/stages-tlr/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/connectiongenerator/ConnectionStatesImpl.java
@@ -1,8 +1,10 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator;
 
 import java.io.Serial;
 import java.util.EnumMap;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.connectiongenerator.ConnectionStates;
@@ -26,7 +28,7 @@ public class ConnectionStatesImpl implements ConnectionStates {
     }
 
     @Override
-    public ConnectionStateImpl getConnectionState(Metamodel metamodel) {
+    public @Nullable ConnectionStateImpl getConnectionState(Metamodel metamodel) {
         return connectionStates.get(metamodel);
     }
 }

--- a/tlr/stages-tlr/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/connectiongenerator/informants/NameTypeConnectionInformant.java
+++ b/tlr/stages-tlr/connection-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/connectiongenerator/informants/NameTypeConnectionInformant.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.connectiongenerator.informants;
 
 import java.util.List;
@@ -8,6 +8,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.entity.Entity;
 import edu.kit.kastel.mcse.ardoco.core.api.entity.ModelEntity;
@@ -184,8 +185,8 @@ public class NameTypeConnectionInformant extends Informant {
      * @param typeMappings        the type mappings
      */
     private void addRecommendedInstanceIfNodeNotNull(//
-            Word currentWord, TextState textExtractionState, Entity entity, ImmutableList<NounMapping> nameMappings, ImmutableList<NounMapping> typeMappings,
-            RecommendationState recommendationState) {
+            Word currentWord, TextState textExtractionState, @Nullable Entity entity, ImmutableList<NounMapping> nameMappings,
+            ImmutableList<NounMapping> typeMappings, RecommendationState recommendationState) {
         var nounMappingsByCurrentWord = textExtractionState.getNounMappingsByWord(currentWord);
         if (entity != null && nounMappingsByCurrentWord != null) {
             for (NounMapping nmapping : nounMappingsByCurrentWord) {
@@ -205,7 +206,7 @@ public class NameTypeConnectionInformant extends Informant {
      * @param word                the node for name identification
      * @return the unique matching instance
      */
-    private Entity tryToIdentify(TextState textExtractionState, ImmutableList<String> similarTypes, Word word, Model model) {
+    private @Nullable Entity tryToIdentify(TextState textExtractionState, ImmutableList<String> similarTypes, @Nullable Word word, Model model) {
         if (textExtractionState == null || similarTypes == null || word == null) {
             return null;
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/ArchitectureConfiguration.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/ArchitectureConfiguration.java
@@ -1,7 +1,9 @@
-/* Licensed under MIT 2024-2025. */
+/* Licensed under MIT 2024-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.agents;
 
 import java.io.File;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.ModelFormat;
@@ -10,7 +12,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.pcm.PcmExtractor;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.uml.UmlExtractor;
 
-public record ArchitectureConfiguration(File architectureFile, ModelFormat type, Metamodel metamodel) {
+public record ArchitectureConfiguration(File architectureFile, ModelFormat type, @Nullable Metamodel metamodel) {
     public ArchitectureConfiguration(File architectureFile, ModelFormat type) {
         this(architectureFile, type, null);
     }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/CodeConfiguration.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/CodeConfiguration.java
@@ -1,8 +1,10 @@
-/* Licensed under MIT 2024-2025. */
+/* Licensed under MIT 2024-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.agents;
 
 import java.io.File;
 import java.util.List;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
@@ -10,7 +12,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.Extractor;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.AllLanguagesExtractor;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.CodeExtractor;
 
-public record CodeConfiguration(File code, CodeConfigurationType type, Metamodel metamodel) {
+public record CodeConfiguration(File code, CodeConfigurationType type, @Nullable Metamodel metamodel) {
 
     public CodeConfiguration(File code, CodeConfigurationType type) {
         this(code, type, null);

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/ModelProviderAgent.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/agents/ModelProviderAgent.java
@@ -1,10 +1,11 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.agents;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.data.DataRepository;
 import edu.kit.kastel.mcse.ardoco.core.pipeline.agent.Informant;
@@ -25,12 +26,13 @@ public class ModelProviderAgent extends PipelineAgent {
      * @param architectureConfiguration the architecture configuration
      * @param codeConfiguration         the code configuration
      */
-    public ModelProviderAgent(DataRepository data, ArchitectureConfiguration architectureConfiguration, CodeConfiguration codeConfiguration) {
+    public ModelProviderAgent(DataRepository data, @Nullable ArchitectureConfiguration architectureConfiguration,
+            @Nullable CodeConfiguration codeConfiguration) {
         super(informants(data, architectureConfiguration, codeConfiguration), ModelProviderAgent.class.getSimpleName(), data);
     }
 
-    private static List<? extends Informant> informants(DataRepository data, ArchitectureConfiguration architectureConfiguration,
-            CodeConfiguration codeConfiguration) {
+    private static List<? extends Informant> informants(DataRepository data, @Nullable ArchitectureConfiguration architectureConfiguration,
+            @Nullable CodeConfiguration codeConfiguration) {
         List<Informant> informants = new ArrayList<>();
         if (architectureConfiguration != null) {
             informants.add(new ModelProviderInformant(data, architectureConfiguration.extractor()));
@@ -50,7 +52,7 @@ public class ModelProviderAgent extends PipelineAgent {
     }
 
     public static ModelProviderAgent getModelProviderAgent(DataRepository dataRepository, ImmutableSortedMap<String, String> additionalConfigs,
-            ArchitectureConfiguration architectureConfiguration, CodeConfiguration codeConfiguration) {
+            @Nullable ArchitectureConfiguration architectureConfiguration, @Nullable CodeConfiguration codeConfiguration) {
         if (architectureConfiguration == null && codeConfiguration == null) {
             throw new IllegalArgumentException("At least one configuration must be provided");
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/antlr4/python3/Python3LexerBase.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/antlr4/python3/Python3LexerBase.java
@@ -1,10 +1,11 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.python3;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 
 import org.antlr.v4.runtime.*;
+import org.jspecify.annotations.Nullable;
 
 abstract class Python3LexerBase extends Lexer {
     // A queue where extra tokens are pushed on (see the NEWLINE lexer rule).
@@ -14,7 +15,7 @@ abstract class Python3LexerBase extends Lexer {
     // The amount of opened braces, brackets and parenthesis.
     private int opened = 0;
     // The most recently produced token.
-    private Token lastToken = null;
+    private @Nullable Token lastToken = null;
 
     protected Python3LexerBase(CharStream input) {
         super(input);

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/elements/Element.java
@@ -13,7 +13,7 @@ import org.jspecify.annotations.Nullable;
  */
 
 public class Element {
-    protected ElementIdentifier identifierOfParent;
+    protected @Nullable ElementIdentifier identifierOfParent;
     protected final ElementIdentifier identifier;
     private int startLine;
     private int endLine;

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/cpp/CppElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/cpp/CppElementExtractor.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.cpp.CPP14Lexer;
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.cpp.CPP14Parser;
@@ -90,7 +91,7 @@ public class CppElementExtractor extends ElementExtractor {
         }
     }
 
-    public void visitDeclaration(CPP14Parser.DeclarationContext ctx, ElementIdentifier parentIdentifier) {
+    public void visitDeclaration(CPP14Parser.DeclarationContext ctx, @Nullable ElementIdentifier parentIdentifier) {
         if (parentIdentifier == null) {
             parentIdentifier = new ElementIdentifier(PathExtractor.extractNameFromPath(ctx), PathExtractor.extractPath(ctx), Type.FILE);
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/java/JavaElementExtractor.java
@@ -11,6 +11,7 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.java.JavaLexer;
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.java.JavaParser;
@@ -108,7 +109,7 @@ public class JavaElementExtractor extends ElementExtractor {
         }
     }
 
-    public ElementIdentifier visitClassDeclaration(JavaParser.ClassDeclarationContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitClassDeclaration(JavaParser.ClassDeclarationContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.identifier() == null) {
             return null;
         }
@@ -139,7 +140,7 @@ public class JavaElementExtractor extends ElementExtractor {
         return identifier;
     }
 
-    public ElementIdentifier visitEnumDeclaration(JavaParser.EnumDeclarationContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitEnumDeclaration(JavaParser.EnumDeclarationContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.identifier() == null) {
             return null;
         }
@@ -153,7 +154,7 @@ public class JavaElementExtractor extends ElementExtractor {
         return identifier;
     }
 
-    public ElementIdentifier visitRecordDeclaration(JavaParser.RecordDeclarationContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitRecordDeclaration(JavaParser.RecordDeclarationContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.identifier() == null) {
             return null;
         }
@@ -169,7 +170,7 @@ public class JavaElementExtractor extends ElementExtractor {
         return identifier;
     }
 
-    public ElementIdentifier visitInterfaceDeclaration(JavaParser.InterfaceDeclarationContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitInterfaceDeclaration(JavaParser.InterfaceDeclarationContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.identifier() == null) {
             return null;
         }
@@ -183,7 +184,7 @@ public class JavaElementExtractor extends ElementExtractor {
         return identifier;
     }
 
-    public ElementIdentifier visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.identifier() == null) {
             return null;
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/extraction/python3/Python3ElementExtractor.java
@@ -12,6 +12,7 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.python3.Python3Lexer;
 import edu.kit.kastel.mcse.ardoco.tlr.models.antlr4.python3.Python3Parser;
@@ -123,7 +124,7 @@ public class Python3ElementExtractor extends ElementExtractor {
         }
     }
 
-    public ElementIdentifier visitClassdef(Python3Parser.ClassdefContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitClassdef(Python3Parser.ClassdefContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.name() == null) {
             return null;
         }
@@ -144,7 +145,7 @@ public class Python3ElementExtractor extends ElementExtractor {
         return identifier;
     }
 
-    public ElementIdentifier visitFuncdef(Python3Parser.FuncdefContext ctx, ElementIdentifier parentIdentifier) {
+    public @Nullable ElementIdentifier visitFuncdef(Python3Parser.FuncdefContext ctx, ElementIdentifier parentIdentifier) {
         if (ctx.name() == null) {
             return null;
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/management/commentmatching/CommentMatcher.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/management/commentmatching/CommentMatcher.java
@@ -1,7 +1,9 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.management.commentmatching;
 
 import java.util.List;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.elements.Comment;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.elements.Element;
@@ -25,7 +27,7 @@ public class CommentMatcher {
         }
     }
 
-    private Element findClosestElement(Comment comment, List<Element> allElements) {
+    private @Nullable Element findClosestElement(Comment comment, List<Element> allElements) {
         int closestLineDifferenceSoFar = Integer.MAX_VALUE;
         Element closestElement = null;
 

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/AbstractCodeItemMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/AbstractCodeItemMapper.java
@@ -1,9 +1,11 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping;
 
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
@@ -41,7 +43,7 @@ public abstract class AbstractCodeItemMapper implements CodeItemMapper {
 
     protected abstract List<Element> getContentOfIdentifier(ElementIdentifier identifier);
 
-    protected CodeItem buildCodeItemFromStrategy(Element element) {
+    protected @Nullable CodeItem buildCodeItemFromStrategy(Element element) {
         return collection.buildCodeItem(element);
     }
 

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/CodeItemMapper.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/CodeItemMapper.java
@@ -1,5 +1,7 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.elements.Element;
@@ -10,7 +12,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.element
  */
 public interface CodeItemMapper {
 
-    public CodeItem buildCodeItem(Element element);
+    public @Nullable CodeItem buildCodeItem(Element element);
 
     public boolean supports(Element element);
 

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/CodeItemMapperCollection.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/antlr/mapping/CodeItemMapperCollection.java
@@ -1,7 +1,9 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.mapping;
 
 import java.util.List;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItem;
 import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.elements.Element;
@@ -13,7 +15,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.antlr.element
 public abstract class CodeItemMapperCollection {
     protected List<CodeItemMapper> mappers;
 
-    public CodeItem buildCodeItem(Element element) {
+    public @Nullable CodeItem buildCodeItem(Element element) {
         var mapper = mappers.stream().filter(strategy -> strategy.supports(element)).findFirst();
         if (mapper.isEmpty()) {
             return null;

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/architecture/pcm/parser/PcmComponent.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/architecture/pcm/parser/PcmComponent.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.pcm.parser;
 
 import java.util.ArrayList;
@@ -7,6 +7,7 @@ import java.util.List;
 import org.fuchss.xmlobjectmapper.annotation.XMLClass;
 import org.fuchss.xmlobjectmapper.annotation.XMLList;
 import org.fuchss.xmlobjectmapper.annotation.XMLValue;
+import org.jspecify.annotations.Nullable;
 
 @XMLClass
 public final class PcmComponent {
@@ -27,7 +28,7 @@ public final class PcmComponent {
     private List<InterfaceId> providedInterfaceIds;
 
     @XMLList(name = "assemblyContexts__ComposedStructure", elementType = ComponentId.class)
-    private List<ComponentId> innerComponents;
+    private @Nullable List<ComponentId> innerComponents;
 
     private List<PcmInterface> required;
     private List<PcmInterface> provided;
@@ -73,9 +74,9 @@ public final class PcmComponent {
     @XMLClass
     static final class InterfaceId {
         @XMLValue(name = "providedInterface__OperationProvidedRole", mandatory = false)
-        private String provided;
+        private @Nullable String provided;
         @XMLValue(name = "requiredInterface__OperationRequiredRole", mandatory = false)
-        private String required;
+        private @Nullable String required;
 
         public String id() {
             if (provided == null && required == null)

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/architecture/pcm/parser/PcmParameter.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/architecture/pcm/parser/PcmParameter.java
@@ -1,10 +1,11 @@
-/* Licensed under MIT 2023. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.pcm.parser;
 
 import java.util.List;
 
 import org.fuchss.xmlobjectmapper.annotation.XMLClass;
 import org.fuchss.xmlobjectmapper.annotation.XMLValue;
+import org.jspecify.annotations.Nullable;
 
 @XMLClass
 public final class PcmParameter {
@@ -15,7 +16,7 @@ public final class PcmParameter {
     @XMLValue(name = "dataType__Parameter", mandatory = false)
     private String typeId;
 
-    private PcmDatatype type;
+    private @Nullable PcmDatatype type;
 
     PcmParameter() {
         // NOP
@@ -25,7 +26,7 @@ public final class PcmParameter {
         return parameterName;
     }
 
-    public PcmDatatype getType() {
+    public @Nullable PcmDatatype getType() {
         return type;
     }
 

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/architecture/pcm/parser/PcmSignature.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/architecture/pcm/parser/PcmSignature.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.architecture.pcm.parser;
 
 import java.util.ArrayList;
@@ -7,6 +7,7 @@ import java.util.List;
 import org.fuchss.xmlobjectmapper.annotation.XMLClass;
 import org.fuchss.xmlobjectmapper.annotation.XMLList;
 import org.fuchss.xmlobjectmapper.annotation.XMLValue;
+import org.jspecify.annotations.Nullable;
 
 @XMLClass
 public final class PcmSignature {
@@ -23,7 +24,7 @@ public final class PcmSignature {
     @XMLList(name = "parameters__OperationSignature", elementType = PcmParameter.class)
     private List<PcmParameter> parameters;
 
-    private PcmDatatype returnType;
+    private @Nullable PcmDatatype returnType;
 
     PcmSignature() {
         // NOP
@@ -37,7 +38,7 @@ public final class PcmSignature {
         return entityName;
     }
 
-    public PcmDatatype getReturnType() {
+    public @Nullable PcmDatatype getReturnType() {
         return returnType;
     }
 

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/AllLanguagesExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/AllLanguagesExtractor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code;
 
 import java.util.ArrayList;
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModelWithCompilationUnits;
@@ -22,7 +24,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.shell.Sh
 public final class AllLanguagesExtractor extends CodeExtractor {
 
     private final Map<ProgrammingLanguage, CodeExtractor> codeExtractors;
-    private CodeModel codeModel;
+    private @Nullable CodeModel codeModel;
 
     public AllLanguagesExtractor(CodeItemRepository codeItemRepository, String path, Metamodel metamodelToExtract) {
         super(codeItemRepository, path, metamodelToExtract);

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/CodeExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/CodeExtractor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code;
 
 import static edu.kit.kastel.mcse.ardoco.core.common.JsonHandling.createObjectMapper;
@@ -6,6 +6,7 @@ import static edu.kit.kastel.mcse.ardoco.core.common.JsonHandling.createObjectMa
 import java.io.File;
 import java.io.IOException;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,7 @@ public abstract class CodeExtractor extends Extractor {
         writeOutCodeModel(codeModel, file);
     }
 
-    public static CodeModel readInCodeModel(File codeModelFile, Metamodel metamodelToExtract) {
+    public static @Nullable CodeModel readInCodeModel(@Nullable File codeModelFile, Metamodel metamodelToExtract) {
         if (codeModelFile != null && codeModelFile.isFile()) {
             logger.info("Reading in existing code model.");
             ObjectMapper objectMapper = createObjectMapper();

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaExtractor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.java;
 
 import java.net.URI;
@@ -15,6 +15,7 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.FileASTRequestor;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ public final class JavaExtractor extends CodeExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(JavaExtractor.class);
 
-    private CodeModel codeModel;
+    private @Nullable CodeModel codeModel;
 
     /**
      * Creates a new JavaExtractor instance.

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/java/JavaModel.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jdt.core.dom.*;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModelWithCompilationUnits;
@@ -323,7 +324,7 @@ public final class JavaModel {
         return packageNames;
     }
 
-    private CodePackage getPackage(List<String> packageNames, CodeCompilationUnit codeCompilationUnit) {
+    private @Nullable CodePackage getPackage(List<String> packageNames, CodeCompilationUnit codeCompilationUnit) {
         if (packageNames.isEmpty()) {
             return null;
         }

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/shell/ShellExtractor.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/connectors/generators/code/shell/ShellExtractor.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2023-2025. */
+/* Licensed under MIT 2023-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.shell;
 
 import java.io.File;
@@ -7,6 +7,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.jspecify.annotations.Nullable;
+
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.code.CodeItemRepository;
@@ -14,7 +16,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.CodeExtr
 
 public final class ShellExtractor extends CodeExtractor {
 
-    private CodeModel codeModel;
+    private @Nullable CodeModel codeModel;
 
     public ShellExtractor(CodeItemRepository codeItemRepository, String path, Metamodel metamodelToExtract) {
         super(codeItemRepository, path, metamodelToExtract);

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/informants/LlmArchitectureProviderInformant.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/informants/LlmArchitectureProviderInformant.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2024-2025. */
+/* Licensed under MIT 2024-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.informants;
 
 import static edu.kit.kastel.mcse.ardoco.tlr.models.informants.LlmArchitecturePrompt.Features.PACKAGES;
@@ -12,6 +12,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,14 +43,15 @@ public class LlmArchitectureProviderInformant extends Informant {
 
     private static final Logger logger = LoggerFactory.getLogger(LlmArchitectureProviderInformant.class);
 
-    private final ChatModel chatLanguageModel;
-    private final LlmArchitecturePrompt documentationPrompt;
-    private final LlmArchitecturePrompt codePrompt;
-    private final LlmArchitecturePrompt aggregationPrompt;
-    private final LlmArchitecturePrompt.Features codeFeature;
+    private final @Nullable ChatModel chatLanguageModel;
+    private final @Nullable LlmArchitecturePrompt documentationPrompt;
+    private final @Nullable LlmArchitecturePrompt codePrompt;
+    private final @Nullable LlmArchitecturePrompt aggregationPrompt;
+    private final LlmArchitecturePrompt.@Nullable Features codeFeature;
 
-    public LlmArchitectureProviderInformant(DataRepository dataRepository, LargeLanguageModel largeLanguageModel, LlmArchitecturePrompt documentation,
-            LlmArchitecturePrompt code, LlmArchitecturePrompt.Features codeFeature, LlmArchitecturePrompt aggregation) {
+    public LlmArchitectureProviderInformant(DataRepository dataRepository, @Nullable LargeLanguageModel largeLanguageModel,
+            @Nullable LlmArchitecturePrompt documentation, @Nullable LlmArchitecturePrompt code, LlmArchitecturePrompt.@Nullable Features codeFeature,
+            @Nullable LlmArchitecturePrompt aggregation) {
         super(LlmArchitectureProviderInformant.class.getSimpleName(), dataRepository);
         String apiKey = Environment.getEnv("OPENAI_API_KEY");
         String orgId = Environment.getEnv("OPENAI_ORGANIZATION_ID");

--- a/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/informants/ModelProviderInformant.java
+++ b/tlr/stages-tlr/model-provider/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/models/informants/ModelProviderInformant.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.models.informants;
 
 import java.io.File;
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.CodeModel;
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
@@ -22,9 +23,9 @@ import edu.kit.kastel.mcse.ardoco.tlr.models.connectors.generators.code.CodeExtr
  */
 public final class ModelProviderInformant extends Informant {
     private static final String MODEL_STATES_DATA = "ModelStatesData";
-    private final Extractor extractor;
-    private final File fromFile;
-    private final Metamodel metamodel;
+    private final @Nullable Extractor extractor;
+    private final @Nullable File fromFile;
+    private final @Nullable Metamodel metamodel;
 
     // Needed for Configuration Generation
     private ModelProviderInformant() {
@@ -53,7 +54,7 @@ public final class ModelProviderInformant extends Informant {
      * @param dataRepository the data repository
      * @param extractor      the model connector
      */
-    public ModelProviderInformant(DataRepository dataRepository, Extractor extractor) {
+    public ModelProviderInformant(DataRepository dataRepository, @Nullable Extractor extractor) {
         super("Extractor " + (extractor == null ? "File" : extractor.getClass().getSimpleName()), dataRepository);
         this.extractor = extractor;
         this.fromFile = null;

--- a/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/RecommendationStateImpl.java
+++ b/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/RecommendationStateImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator;
 
 import java.io.Serial;
@@ -7,6 +7,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.SortedSets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator.RecommendationState;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator.RecommendedInstance;
@@ -118,7 +119,7 @@ public class RecommendationStateImpl extends AbstractState implements Recommenda
     }
 
     @Override
-    public void onNounMappingDeletion(NounMapping nounMapping, NounMapping replacement) {
+    public void onNounMappingDeletion(NounMapping nounMapping, @Nullable NounMapping replacement) {
         for (RecommendedInstance ri : this.recommendedInstances.toImmutable()) {
             ri.onNounMappingDeletion(nounMapping, replacement);
         }

--- a/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/RecommendationStatesImpl.java
+++ b/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/RecommendationStatesImpl.java
@@ -1,8 +1,10 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator;
 
 import java.io.Serial;
 import java.util.EnumMap;
+
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Metamodel;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator.RecommendationStates;
@@ -26,7 +28,7 @@ public class RecommendationStatesImpl implements RecommendationStates {
     }
 
     @Override
-    public RecommendationStateImpl getRecommendationState(Metamodel metamodel) {
+    public @Nullable RecommendationStateImpl getRecommendationState(Metamodel metamodel) {
         return this.recommendationStates.get(metamodel);
     }
 }

--- a/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/RecommendedInstanceImpl.java
+++ b/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/RecommendedInstanceImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator;
 
 import java.io.Serial;
@@ -11,6 +11,7 @@ import java.util.UUID;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.entity.Entity;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator.RecommendedInstance;
@@ -52,7 +53,7 @@ public final class RecommendedInstanceImpl extends RecommendedInstance implement
     }
 
     @Override
-    public void onNounMappingDeletion(NounMapping deletedNounMapping, NounMapping replacement) {
+    public void onNounMappingDeletion(NounMapping deletedNounMapping, @Nullable NounMapping replacement) {
         if (this.nameMappings.remove(deletedNounMapping)) {
             if (replacement == null) {
                 throw new IllegalArgumentException("Replacement cannot be null");

--- a/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/informants/CompoundRecommendationInformant.java
+++ b/tlr/stages-tlr/recommendation-generator/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/recommendationgenerator/informants/CompoundRecommendationInformant.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.recommendationgenerator.informants;
 
 import org.eclipse.collections.api.factory.Lists;
@@ -7,6 +7,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.models.Model;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.recommendationgenerator.RecommendationState;
@@ -148,8 +149,8 @@ public class CompoundRecommendationInformant extends Informant {
         return typeMappings.toImmutable();
     }
 
-    private void addRecommendedInstanceIfCompoundWithOtherWord(NounMapping nounMapping, Word word, TextState textState, RecommendationState recommendationState,
-            Model model) {
+    private void addRecommendedInstanceIfCompoundWithOtherWord(NounMapping nounMapping, @Nullable Word word, TextState textState,
+            RecommendationState recommendationState, Model model) {
         if (word == null) {
             return;
         }

--- a/tlr/stages-tlr/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/textextraction/DefaultTextStateStrategy.java
+++ b/tlr/stages-tlr/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/textextraction/DefaultTextStateStrategy.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.textextraction;
 
 import java.util.Arrays;
@@ -14,6 +14,7 @@ import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.api.set.sorted.ImmutableSortedSet;
 import org.eclipse.collections.api.set.sorted.MutableSortedSet;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.MappingKind;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.NounMapping;
@@ -51,7 +52,7 @@ public final class DefaultTextStateStrategy implements TextStateStrategy {
      * @return the created noun mapping
      */
     public NounMapping createNounMappingStateless(ImmutableSortedSet<Word> words, ImmutableSortedMap<MappingKind, Confidence> distribution,
-            ImmutableList<Word> referenceWords, ImmutableList<String> surfaceForms, String reference) {
+            ImmutableList<Word> referenceWords, ImmutableList<String> surfaceForms, @Nullable String reference) {
         if (reference == null) {
             reference = this.calculateNounMappingReference(referenceWords);
         }
@@ -61,7 +62,7 @@ public final class DefaultTextStateStrategy implements TextStateStrategy {
 
     @Override
     public NounMapping addNounMapping(ImmutableSortedSet<Word> words, ImmutableSortedMap<MappingKind, Confidence> distribution,
-            ImmutableList<Word> referenceWords, ImmutableList<String> surfaceForms, String reference) {
+            ImmutableList<Word> referenceWords, ImmutableList<String> surfaceForms, @Nullable String reference) {
         //Do not add noun mappings to the state, which do not have any claimants
         if (distribution.valuesView().noneSatisfy(d -> !d.getClaimants().isEmpty())) {
             throw new IllegalArgumentException("Atleast 1 claimant is required");
@@ -74,7 +75,7 @@ public final class DefaultTextStateStrategy implements TextStateStrategy {
 
     @Override
     public NounMapping addNounMapping(ImmutableSortedSet<Word> words, MappingKind kind, Claimant claimant, double probability,
-            ImmutableList<Word> referenceWords, ImmutableList<String> surfaceForms, String reference) {
+            ImmutableList<Word> referenceWords, ImmutableList<String> surfaceForms, @Nullable String reference) {
         MutableSortedMap<MappingKind, Confidence> distribution = SortedMaps.mutable.empty();
         distribution.put(MappingKind.NAME, new Confidence(DEFAULT_AGGREGATOR));
         distribution.put(MappingKind.TYPE, new Confidence(DEFAULT_AGGREGATOR));
@@ -135,8 +136,8 @@ public final class DefaultTextStateStrategy implements TextStateStrategy {
     }
 
     @Override
-    public NounMappingImpl mergeNounMappingsStateless(NounMapping firstNounMapping, NounMapping secondNounMapping, ImmutableList<Word> referenceWords,
-            String reference, MappingKind mappingKind, Claimant claimant, double probability) {
+    public NounMappingImpl mergeNounMappingsStateless(NounMapping firstNounMapping, NounMapping secondNounMapping, @Nullable ImmutableList<Word> referenceWords,
+            @Nullable String reference, MappingKind mappingKind, Claimant claimant, double probability) {
 
         MutableSortedSet<Word> mergedWords = firstNounMapping.getWords().toSortedSet();
         mergedWords.add(secondNounMapping.getReferenceWords().get(0));
@@ -168,8 +169,8 @@ public final class DefaultTextStateStrategy implements TextStateStrategy {
     }
 
     @Override
-    public NounMappingImpl mergeNounMappings(NounMapping firstNounMapping, NounMapping secondNounMapping, ImmutableList<Word> referenceWords, String reference,
-            MappingKind mappingKind, Claimant claimant, double probability) {
+    public NounMappingImpl mergeNounMappings(NounMapping firstNounMapping, NounMapping secondNounMapping, @Nullable ImmutableList<Word> referenceWords,
+            @Nullable String reference, MappingKind mappingKind, Claimant claimant, double probability) {
         var mergedNounMapping = this.mergeNounMappingsStateless(firstNounMapping, secondNounMapping, referenceWords, reference, mappingKind, claimant,
                 probability);
 

--- a/tlr/stages-tlr/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/textextraction/TextStateImpl.java
+++ b/tlr/stages-tlr/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/textextraction/TextStateImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2021-2025. */
+/* Licensed under MIT 2021-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.textextraction;
 
 import java.io.Serial;
@@ -9,6 +9,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.ordered.SortedIterable;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.MappingKind;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.NounMapping;
@@ -79,7 +80,7 @@ public class TextStateImpl extends AbstractState implements TextState {
     }
 
     @Override
-    public ImmutableList<NounMapping> getMappingsThatCouldBeMultipleKinds(Word word, MappingKind... kinds) {
+    public ImmutableList<NounMapping> getMappingsThatCouldBeMultipleKinds(@Nullable Word word, MappingKind... kinds) {
         if (kinds.length == 0) {
             throw new IllegalArgumentException("You need to provide some mapping kinds!");
         }
@@ -132,7 +133,7 @@ public class TextStateImpl extends AbstractState implements TextState {
     }
 
     @Override
-    public void removeNounMapping(DataRepository dataRepository, NounMapping nounMapping, NounMapping replacement, boolean cascade) {
+    public void removeNounMapping(DataRepository dataRepository, NounMapping nounMapping, @Nullable NounMapping replacement, boolean cascade) {
 
         if (cascade) {
             PhraseMapping phraseMapping = this.getPhraseMappingByNounMapping(nounMapping);

--- a/tlr/stages-tlr/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/textextraction/informants/MappingCombinerInformant.java
+++ b/tlr/stages-tlr/text-extraction/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/textextraction/informants/MappingCombinerInformant.java
@@ -1,10 +1,11 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.textextraction.informants;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.NounMapping;
 import edu.kit.kastel.mcse.ardoco.core.api.stage.textextraction.PhraseMapping;
@@ -108,7 +109,8 @@ public class MappingCombinerInformant extends TextExtractionInformant {
         }
     }
 
-    private NounMapping getMostSimilarNounMappingOverThreshold(NounMapping nounMapping, ImmutableList<NounMapping> nounMappingsOfSimilarPhraseMapping) {
+    private @Nullable NounMapping getMostSimilarNounMappingOverThreshold(NounMapping nounMapping,
+            ImmutableList<NounMapping> nounMappingsOfSimilarPhraseMapping) {
 
         MutableList<NounMapping> similarNounMappings = Lists.mutable.empty();
 

--- a/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/CoreNLPProvider.java
+++ b/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/CoreNLPProvider.java
@@ -1,7 +1,8 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.text.providers.informants.corenlp;
 
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.PreprocessingData;
 import edu.kit.kastel.mcse.ardoco.core.api.text.NlpInformant;
@@ -12,7 +13,7 @@ import edu.kit.kastel.mcse.ardoco.tlr.text.providers.informants.corenlp.textproc
 
 public class CoreNLPProvider extends NlpInformant {
 
-    private Text annotatedText;
+    private @Nullable Text annotatedText;
 
     // Needed for Configuration Generation
     private CoreNLPProvider() {

--- a/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/PhraseImpl.java
+++ b/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/PhraseImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.text.providers.informants.corenlp;
 
 import java.io.Serial;
@@ -13,6 +13,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.map.sorted.ImmutableSortedMap;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.Phrase;
 import edu.kit.kastel.mcse.ardoco.core.api.text.PhraseType;
@@ -30,7 +31,7 @@ public class PhraseImpl implements Phrase {
 
     private final SentenceImpl parent;
 
-    private String text = null;
+    private @Nullable String text = null;
 
     public PhraseImpl(Tree tree, ImmutableList<Word> words, SentenceImpl parent) {
         this.tree = tree;

--- a/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/SentenceImpl.java
+++ b/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/SentenceImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.text.providers.informants.corenlp;
 
 import java.io.IOException;
@@ -11,6 +11,7 @@ import java.util.Objects;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ class SentenceImpl implements Sentence {
 
     private final TextImpl parent;
     private final transient CoreSentence coreSentence;
-    private SemanticGraph semanticGraph;
+    private @Nullable SemanticGraph semanticGraph;
     private final int sentenceNumber;
 
     private final String text;

--- a/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/WordImpl.java
+++ b/tlr/stages-tlr/text-preprocessing/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/text/providers/informants/corenlp/WordImpl.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2022-2025. */
+/* Licensed under MIT 2022-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.text.providers.informants.corenlp;
 
 import java.io.Serial;
@@ -8,6 +8,7 @@ import java.util.Objects;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.factory.Lists;
+import org.jspecify.annotations.Nullable;
 
 import edu.kit.kastel.mcse.ardoco.core.api.text.DependencyTag;
 import edu.kit.kastel.mcse.ardoco.core.api.text.POSTag;
@@ -27,11 +28,11 @@ class WordImpl implements Word {
     private final CoreLabel token;
     private final TextImpl parent;
     private final int index;
-    private Word preWord = null;
-    private Word nextWord = null;
+    private @Nullable Word preWord = null;
+    private @Nullable Word nextWord = null;
 
     private final int sentenceNo;
-    private Phrase phrase;
+    private @Nullable Phrase phrase;
     private final String text;
     private final POSTag posTag;
 
@@ -84,7 +85,7 @@ class WordImpl implements Word {
     }
 
     @Override
-    public Word getPreWord() {
+    public @Nullable Word getPreWord() {
         int preWordIndex = index - 1;
         if (preWord == null && preWordIndex > 0) {
             preWord = parent.getWord(preWordIndex);
@@ -93,7 +94,7 @@ class WordImpl implements Word {
     }
 
     @Override
-    public Word getNextWord() {
+    public @Nullable Word getNextWord() {
         int nextWordIndex = index + 1;
         if (nextWord == null && nextWordIndex < parent.getNumberOfWords()) {
             nextWord = parent.getWord(nextWordIndex);


### PR DESCRIPTION
This pull request introduces improvements to nullability handling in the core code model API. The main theme is the adoption of `@Nullable` annotations for various fields, parameters, and return types across several model classes. This makes the codebase more robust and explicit about which values can be null, improving clarity for both developers and static analysis tools.
